### PR TITLE
Permission framework

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -61,7 +61,7 @@ app.use(
 
 const logStream = {
   write: (message) => {
-    log.info(message)
+    log.http(message)
   },
 }
 
@@ -120,7 +120,7 @@ function addLoginPassportUse(discovery, strategyName, callbackURI, kc_idp_hint, 
         scope: 'openid',
         kc_idp_hint: kc_idp_hint,
       },
-      (_issuer, profile, _context, _idToken, accessToken, refreshToken, done) => {
+      async (_issuer, profile, _context, _idToken, accessToken, refreshToken, done) => {
         if (typeof accessToken === 'undefined' || accessToken === null || typeof refreshToken === 'undefined' || refreshToken === null) {
           return done('No access token', null)
         }
@@ -129,7 +129,7 @@ function addLoginPassportUse(discovery, strategyName, callbackURI, kc_idp_hint, 
         log.info('addLoginPassportUse')
         log.info(profile)
         // Get role
-        profile.jwtFrontend = auth.generateUiToken(profile.username)
+        profile.jwtFrontend = await auth.generateUiToken(profile.username)
         profile.jwt = accessToken
         profile._json = parseJwt(accessToken)
         profile.refreshToken = refreshToken

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -126,7 +126,10 @@ function addLoginPassportUse(discovery, strategyName, callbackURI, kc_idp_hint, 
         }
 
         //set access and refresh tokens
-        profile.jwtFrontend = auth.generateUiToken()
+        log.info('addLoginPassportUse')
+        log.info(profile)
+        // Get role
+        profile.jwtFrontend = auth.generateUiToken(profile.username)
         profile.jwt = accessToken
         profile._json = parseJwt(accessToken)
         profile.refreshToken = refreshToken

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -126,9 +126,6 @@ function addLoginPassportUse(discovery, strategyName, callbackURI, kc_idp_hint, 
         }
 
         //set access and refresh tokens
-        log.info('addLoginPassportUse')
-        log.info(profile)
-        // Get role
         profile.jwtFrontend = await auth.generateUiToken(profile.username)
         profile.jwt = accessToken
         profile._json = parseJwt(accessToken)

--- a/backend/src/components/auth.js
+++ b/backend/src/components/auth.js
@@ -101,13 +101,14 @@ const auth = {
     next()
   },
 
-  generateUiToken() {
+  generateUiToken(subject) {
+    log.error('generateUiToken')
+    // TODO Get UserProfile for BCeID users
     const i = config.get('tokenGenerate:issuer')
-    const s = 'user@penrequest.ca'
     const a = config.get('server:frontend')
     const signOptions = {
       issuer: i,
-      subject: s,
+      subject,
       audience: a,
       expiresIn: '30m',
       algorithm: 'RS256',

--- a/backend/src/components/auth.js
+++ b/backend/src/components/auth.js
@@ -127,6 +127,7 @@ const auth = {
         org: user?.organization?.accountid,
       }
     }
+    // TODO (weskubo-cgi) Handle hardcoded roles for Impersonate
 
     const privateKey = config.get('tokenGenerate:privateKey')
     const uiToken = jsonwebtoken.sign(payload, privateKey, signOptions)

--- a/backend/src/components/lookup.js
+++ b/backend/src/components/lookup.js
@@ -55,7 +55,7 @@ async function getRoles() {
   if (!roles) {
     roles = []
     const response = await getOperation(
-      'ofm_portal_roles?$select=ofm_name,ofm_portal_role_number&$expand=ofm_portal_role_permission($select=ofm_portal_permissionid,ofm_portal_privilege;$expand=ofm_portal_privilege($select=ofm_portal_privilege_number,ofm_category,ofm_name))',
+      'ofm_portal_roles?$select=ofm_name,ofm_portal_role_number&$expand=ofm_portal_role_permission($select=ofm_portal_permissionid,ofm_portal_privilege;$expand=ofm_portal_privilege($select=ofm_portal_privilege_number,ofm_category,ofm_name))&pageSize=100',
     )
     response?.value?.forEach((item) => {
       const role = new MappableObjectForFront(item, RoleMappings)

--- a/backend/src/components/lookup.js
+++ b/backend/src/components/lookup.js
@@ -108,4 +108,5 @@ async function getLookupInfo(_req, res) {
 
 module.exports = {
   getLookupInfo,
+  getRoles,
 }

--- a/backend/src/components/lookup.js
+++ b/backend/src/components/lookup.js
@@ -66,18 +66,24 @@ async function getLicenceTypes() {
   return fetchAndCacheData('licenceTypes', 'ecc_licence_type')
 }
 
+function getRoles() {
+  // TODO (weskubo-cgi) Replace with D365 API call
+  return [{ role: 'Administrator', permissions: [] }]
+}
+
 /**
  * Look ups from Dynamics365.
  */
 async function getLookupInfo(_req, res) {
   try {
-    const [requestCategories, requestSubCategories, userRoles, healthAuthorities, facilityTypes, licenceTypes] = await Promise.all([
+    const [requestCategories, requestSubCategories, userRoles, healthAuthorities, facilityTypes, licenceTypes, roles] = await Promise.all([
       getRequestCategories(),
       getRequestSubCategories(),
       getUserRoles(),
       getHealthAuthorities(),
       getFacilityTypes(),
       getLicenceTypes(),
+      getRoles(),
     ])
     const resData = {
       requestCategories: requestCategories,
@@ -86,6 +92,7 @@ async function getLookupInfo(_req, res) {
       healthAuthorities: healthAuthorities,
       facilityTypes: facilityTypes,
       licenceTypes: licenceTypes,
+      roles: roles,
     }
     return res.status(HttpStatus.OK).json(resData)
   } catch (e) {

--- a/backend/src/components/lookup.js
+++ b/backend/src/components/lookup.js
@@ -49,6 +49,10 @@ async function fetchAndCacheData(cacheKey, operationName) {
   }
   return data
 }
+// TODO (weskubo-cgi) Remove this
+async function getUserRoles() {
+  return fetchAndCacheData('userRoles', 'ofm_portal_role')
+}
 
 async function getRoles() {
   let roles = lookupCache.get('roles')
@@ -84,9 +88,10 @@ async function getLicenceTypes() {
  */
 async function getLookupInfo(_req, res) {
   try {
-    const [requestCategories, requestSubCategories, roles, healthAuthorities, facilityTypes, licenceTypes] = await Promise.all([
+    const [requestCategories, requestSubCategories, userRoles, roles, healthAuthorities, facilityTypes, licenceTypes] = await Promise.all([
       getRequestCategories(),
       getRequestSubCategories(),
+      getUserRoles(),
       getRoles(),
       getHealthAuthorities(),
       getFacilityTypes(),
@@ -95,6 +100,8 @@ async function getLookupInfo(_req, res) {
     const resData = {
       requestCategories: requestCategories,
       requestSubCategories: requestSubCategories,
+      // TODO (weskubo-cgi) Remove this
+      userRoles: userRoles,
       roles: roles,
       healthAuthorities: healthAuthorities,
       facilityTypes: facilityTypes,

--- a/backend/src/components/user.js
+++ b/backend/src/components/user.js
@@ -316,6 +316,7 @@ module.exports = {
   getUserByBCeID,
   getUserFacilities,
   getUserInfo,
+  getUserProfile,
   getUsersPermissionsFacilities,
   updateUser,
   updateUserFacilityPermission,

--- a/backend/src/components/utils.js
+++ b/backend/src/components/utils.js
@@ -145,7 +145,7 @@ async function deleteOperation(operation) {
 async function getOperation(operation) {
   try {
     const url = config.get('dynamicsApi:apiEndpoint') + '/api/Operations?statement=' + operation
-    log.info('get Data Url', url)
+    log.verbose('get Data Url', url)
     const response = await axios.get(url, getHttpHeader())
     //logResponse('getOperation', response);
     return response.data

--- a/backend/src/middlewares/validatePermission.js
+++ b/backend/src/middlewares/validatePermission.js
@@ -1,0 +1,8 @@
+const log = require('../components/logger')
+
+module.exports = function (permission) {
+  return function (req, res, next) {
+    log.info(`validating permission ${permission}`)
+    next()
+  }
+}

--- a/backend/src/middlewares/validatePermission.js
+++ b/backend/src/middlewares/validatePermission.js
@@ -1,8 +1,21 @@
+const jsonwebtoken = require('jsonwebtoken')
 const log = require('../components/logger')
+const { getRoles } = require('../components/lookup')
 
 module.exports = function (permission) {
-  return function (req, res, next) {
-    log.info(`validating permission ${permission}`)
-    next()
+  return async function (req, res, next) {
+    log.verbose(`validating permission ${permission}`)
+
+    const authHeader = req.headers['authorization']
+    const token = authHeader && authHeader.split(' ')[1]
+    const payload = jsonwebtoken.decode(token)
+
+    const roles = await getRoles()
+    const matchingRole = roles.find((role) => role.data.roleId === payload.role.ofm_portal_roleid)
+    const permissions = matchingRole ? matchingRole.data.permissions : []
+
+    const valid = permissions.some((p) => p.permissionName === permission)
+
+    valid ? next() : res.sendStatus(403)
   }
 }

--- a/backend/src/routes/applications.js
+++ b/backend/src/routes/applications.js
@@ -15,6 +15,7 @@ const {
 } = require('../components/applications')
 const { param, validationResult, checkSchema } = require('express-validator')
 const validatePermission = require('../middlewares/validatePermission.js')
+const { PERMISSIONS } = require('../util/constants')
 
 module.exports = router
 
@@ -28,7 +29,7 @@ const createApplicationSchema = {
 /**
  * Get the list of applications
  */
-router.get('/', passport.authenticate('jwt', { session: false }), isValidBackendToken, validatePermission('View Application'), (req, res) => {
+router.get('/', passport.authenticate('jwt', { session: false }), isValidBackendToken, validatePermission(PERMISSIONS.VIEW_APPLICATIONS), (req, res) => {
   validationResult(req).throw()
   return getApplications(req, res)
 })
@@ -44,10 +45,17 @@ router.post('/', passport.authenticate('jwt', { session: false }), isValidBacken
 /**
  * Get an existing Application details using applicationId
  */
-router.get('/:applicationId', passport.authenticate('jwt', { session: false }), isValidBackendToken, [param('applicationId', 'URL param: [applicationId] is required').not().isEmpty()], (req, res) => {
-  validationResult(req).throw()
-  return getApplication(req, res)
-})
+router.get(
+  '/:applicationId',
+  passport.authenticate('jwt', { session: false }),
+  isValidBackendToken,
+  validatePermission(PERMISSIONS.VIEW_APPLICATIONS),
+  [param('applicationId', 'URL param: [applicationId] is required').not().isEmpty()],
+  (req, res) => {
+    validationResult(req).throw()
+    return getApplication(req, res)
+  },
+)
 
 /**
  * Update an existing Application using applicationId
@@ -64,6 +72,7 @@ router.get(
   '/supplementary/:applicationId',
   passport.authenticate('jwt', { session: false }),
   isValidBackendToken,
+  validatePermission(PERMISSIONS.VIEW_APPLICATIONS),
   [param('applicationId', 'URL param: [applicationId] is required').not().isEmpty()],
   (req, res) => {
     validationResult(req).throw()

--- a/backend/src/routes/applications.js
+++ b/backend/src/routes/applications.js
@@ -14,6 +14,7 @@ const {
   deleteSupplementaryApplication,
 } = require('../components/applications')
 const { param, validationResult, checkSchema } = require('express-validator')
+const validatePermission = require('../middlewares/validatePermission.js')
 
 module.exports = router
 
@@ -27,7 +28,7 @@ const createApplicationSchema = {
 /**
  * Get the list of applications
  */
-router.get('/', passport.authenticate('jwt', { session: false }), isValidBackendToken, (req, res) => {
+router.get('/', passport.authenticate('jwt', { session: false }), isValidBackendToken, validatePermission('View Application'), (req, res) => {
   validationResult(req).throw()
   return getApplications(req, res)
 })

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,168 +1,164 @@
-'use strict';
+'use strict'
 
-const config = require('../config/index');
-const passport = require('passport');
-const express = require('express');
-const auth = require('../components/auth');
-const log = require('../components/logger');
-const {v4: uuidv4} = require('uuid');
-const {getUserGuid} = require('../components/utils');
+const config = require('../config/index')
+const passport = require('passport')
+const express = require('express')
+const auth = require('../components/auth')
+const log = require('../components/logger')
+const { v4: uuidv4 } = require('uuid')
+const { getUserGuid } = require('../components/utils')
 
-const {
-  body,
-  validationResult
-} = require('express-validator');
-const router = express.Router();
-
+const { body, validationResult } = require('express-validator')
+const router = express.Router()
 
 router.get('/', (_req, res) => {
   res.status(200).json({
-    endpoints: [
-      '/callback',
-      '/callback_idir',
-      '/login',
-      '/logout',
-      '/refresh',
-      '/token'
-    ]
-  });
-});
+    endpoints: ['/callback', '/callback_idir', '/login', '/logout', '/refresh', '/token'],
+  })
+})
 
-router.get('/callback',
+router.get(
+  '/callback',
   passport.authenticate('oidcBceid', {
-    failureRedirect: 'error'
+    failureRedirect: 'error',
   }),
   (_req, res) => {
-    res.redirect(config.get('server:frontend'));
-  }
-);
+    res.redirect(config.get('server:frontend'))
+  },
+)
 
-router.get('/callback_idir',
+router.get(
+  '/callback_idir',
   passport.authenticate('oidcIdir', {
-    failureRedirect: 'error'
+    failureRedirect: 'error',
   }),
   (_req, res) => {
-    res.redirect(config.get('server:frontend'));
-  }
-);
-
+    res.redirect(config.get('server:frontend'))
+  },
+)
 
 //a prettier way to handle errors
 router.get('/error', (_req, res) => {
-  res.redirect(config.get('server:frontend') + '/login-error');
-});
+  res.redirect(config.get('server:frontend') + '/login-error')
+})
 
 //redirects to the SSO login screen
-router.get('/login', passport.authenticate('oidcBceid', {
-  failureRedirect: 'error'
-}));
-router.get('/login-idir', passport.authenticate('oidcIdir', {
-  failureRedirect: 'error'
-}));
+router.get(
+  '/login',
+  passport.authenticate('oidcBceid', {
+    failureRedirect: 'error',
+  }),
+)
+router.get(
+  '/login-idir',
+  passport.authenticate('oidcIdir', {
+    failureRedirect: 'error',
+  }),
+)
 
 //removes tokens and destroys session
 router.get('/logout', async (req, res, next) => {
-  req.logout(function(err) {
+  req.logout(function (err) {
     if (err) {
-      return next(err);
+      return next(err)
     }
-    req.session.destroy();
-    let retUrl;
+    req.session.destroy()
+    let retUrl
     if (req.query && req.query.sessionExpired) {
-      retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/session-expired');
+      retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/session-expired')
     } else if (req.query && req.query.loginError) {
-      retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/login-error');
+      retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/login-error')
     } else if (req.query && req.query.loginBceid) {
-      retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/api/auth/login_bceid');
+      retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/api/auth/login_bceid')
     } else if (req.query && req.query.loginBceidActivateUser) {
-      retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/api/auth/login_bceid_activate_user');
+      retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/api/auth/login_bceid_activate_user')
     } else if (req.query && req.query.loginBceidActivateDistrictUser) {
-      retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/api/auth/login_bceid_activate_district_user');
+      retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/api/auth/login_bceid_activate_district_user')
     } else {
-      retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/logout');
+      retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/logout')
     }
-    log.info('URL: ' + config.get('siteMinder_logout_endpoint') + retUrl);
-    res.redirect(config.get('siteMinder_logout_endpoint') + retUrl );
-  });
-});
+    log.info('URL: ' + config.get('siteMinder_logout_endpoint') + retUrl)
+    res.redirect(config.get('siteMinder_logout_endpoint') + retUrl)
+  })
+})
 
 const UnauthorizedRsp = {
   error: 'Unauthorized',
-  error_description: 'Not logged in'
-};
+  error_description: 'Not logged in',
+}
 
 //refreshes jwt on refresh if refreshToken is valid
-router.post('/refresh', [
-  body('refreshToken').exists()
-], async (req, res) => {
-  const errors = validationResult(req);
+router.post('/refresh', [body('refreshToken').exists()], async (req, res) => {
+  const errors = validationResult(req)
 
   if (!errors.isEmpty()) {
     return res.status(400).json({
-      errors: errors.array()
-    });
+      errors: errors.array(),
+    })
   }
   if (!req['user'] || !req['user'].refreshToken || !req?.user?.jwt) {
-    res.status(401).json(UnauthorizedRsp);
+    res.status(401).json(UnauthorizedRsp)
   } else {
     if (auth.isTokenExpired(req.user.jwt)) {
       if (req?.user?.refreshToken && auth.isRenewable(req.user.refreshToken)) {
-        return generateTokens(req, res);
+        return generateTokens(req, res)
       } else {
-        res.status(401).json(UnauthorizedRsp);
+        res.status(401).json(UnauthorizedRsp)
       }
     } else {
       const responseJson = {
-        jwtFrontend: req.user.jwtFrontend
-      };
-      return res.status(200).json(responseJson);
+        jwtFrontend: req.user.jwtFrontend,
+      }
+      return res.status(200).json(responseJson)
     }
   }
-});
+})
 
 //provides a jwt to authenticated users
 router.get('/token', auth.refreshJWT, (req, res) => {
   if (req?.user && req.user?.jwtFrontend && req.user?.refreshToken) {
     if (req.session?.passport?.user?._json) {
-      const correlationID = uuidv4();
-      req.session.correlationID = correlationID;
+      const correlationID = uuidv4()
+      req.session.correlationID = correlationID
       const correlation = {
         user_guid: getUserGuid(req),
-        correlation_id: correlationID
-      };
-      log.info('created correlation id and stored in session', correlation);
+        correlation_id: correlationID,
+      }
+      log.info('created correlation id and stored in session', correlation)
     }
     const responseJson = {
-      jwtFrontend: req.user.jwtFrontend
-    };
-    res.status(200).json(responseJson);
+      jwtFrontend: req.user.jwtFrontend,
+    }
+    res.status(200).json(responseJson)
   } else {
-    res.status(401).json(UnauthorizedRsp);
+    res.status(401).json(UnauthorizedRsp)
   }
-});
+})
 async function generateTokens(req, res) {
-  let isIdir = (req.session?.passport?.user?._json?.idir_user_guid) ? true : false;
-  const result = await auth.renew(req.user.refreshToken, isIdir);
+  let isIdir = req.session?.passport?.user?._json?.idir_user_guid ? true : false
+  const result = await auth.renew(req.user.refreshToken, isIdir)
   if (result && result.jwt && result.refreshToken) {
-    req.user.jwt = result.jwt;
-    req.user.refreshToken = result.refreshToken;
-    req.user.jwtFrontend = auth.generateUiToken();
+    req.user.jwt = result.jwt
+    req.user.refreshToken = result.refreshToken
+    log.info('generateTokens')
+    log.info(req.user)
+    req.user.jwtFrontend = auth.generateUiToken(req.user.username)
     const responseJson = {
-      jwtFrontend: req.user.jwtFrontend
-    };
-    res.status(200).json(responseJson);
+      jwtFrontend: req.user.jwtFrontend,
+    }
+    res.status(200).json(responseJson)
   } else {
-    res.status(401).json(UnauthorizedRsp);
+    res.status(401).json(UnauthorizedRsp)
   }
 }
-router.get('/user-session-remaining-time', passport.authenticate('jwt', {session: false}), (req, res) => {
+router.get('/user-session-remaining-time', passport.authenticate('jwt', { session: false }), (req, res) => {
   if (req?.session?.cookie && req?.session?.passport?.user) {
-    const remainingTime = req.session.cookie.maxAge;
-    log.info(`session remaining time is :: ${remainingTime} for user`, req.session?.passport?.user?.displayName);
-    return res.status(200).json(req.session.cookie.maxAge);
+    const remainingTime = req.session.cookie.maxAge
+    log.info(`session remaining time is :: ${remainingTime} for user`, req.session?.passport?.user?.displayName)
+    return res.status(200).json(req.session.cookie.maxAge)
   } else {
-    return res.sendStatus(401);
+    return res.sendStatus(401)
   }
-});
+})
 
-module.exports = router;
+module.exports = router

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -77,7 +77,7 @@ router.get('/logout', async (req, res, next) => {
     } else {
       retUrl = encodeURIComponent(config.get('logoutEndpoint') + '?redirect_uri=' + config.get('server:frontend') + '/logout')
     }
-    log.info('URL: ' + config.get('siteMinder_logout_endpoint') + retUrl)
+    log.verbose('URL: ' + config.get('siteMinder_logout_endpoint') + retUrl)
     res.redirect(config.get('siteMinder_logout_endpoint') + retUrl)
   })
 })

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -141,8 +141,7 @@ async function generateTokens(req, res) {
     req.user.jwt = result.jwt
     req.user.refreshToken = result.refreshToken
     log.info('generateTokens')
-    log.info(req.user)
-    req.user.jwtFrontend = auth.generateUiToken(req.user.username)
+    req.user.jwtFrontend = await auth.generateUiToken(req.user.username)
     const responseJson = {
       jwtFrontend: req.user.jwtFrontend,
     }

--- a/backend/src/util/constants.js
+++ b/backend/src/util/constants.js
@@ -8,7 +8,40 @@ const SCAN_RESULTS = Object.freeze({
   VIRUS_FOUND: 'FOUND',
 })
 
+const PERMISSIONS = Object.freeze({
+  // Reporting
+  SEARCH_VIEW_REPORTS: 'Search/View Reports',
+  SUBMIT_DRAFT_REPORTS: 'Submit Draft Reports',
+  DELETE_DRAFT_REPORTS: 'Delete Draft Reports',
+
+  // Funding
+  VIEW_FUNDING_AMOUNTS: 'View Funding Amounts',
+  REQUEST_FUNDING_CHANGE: 'Request Funding Change',
+  VIEW_FUNDING_AGREEMENT: 'View Funding Agreement',
+  SIGN_FUNDING_AGREEMENT: 'Sign Funding Agreement',
+
+  // Documents
+  DOCUMENT_MANAGEMENT: 'Document Management',
+
+  // Application
+  VIEW_APPLICATIONS: 'View Applications',
+  APPLY_FOR_FUNDING: 'Apply for Funding',
+
+  // Resources
+  VIEW_RESOURCES: 'View Resources',
+
+  // Account Management
+  VIEW_ORG_FACILITY: 'View Org/Facility Information',
+  UPDATE_ORG_FACILITY: 'Update Org/ facility information',
+  SUBMIT_CHANGE_REQUEST: 'Submit Change Request from AM',
+  MANAGE_USERS: 'Manage Users',
+
+  // Notifications and Messages
+  MANAGE_NOTIFICATIONS: 'Manage Notification and Messages',
+})
+
 module.exports = {
   ASSISTANCE_REQUEST_STATUS_CODES,
   SCAN_RESULTS,
+  PERMISSIONS,
 }

--- a/backend/src/util/mapping/MappableObject.js
+++ b/backend/src/util/mapping/MappableObject.js
@@ -1,33 +1,32 @@
 class MappableObject {
   constructor(input, mappings, from, to) {
-    this.data = {};
+    this.data = {}
 
     if (!input || !mappings) {
-      return;
+      return
     }
 
     for (const item of mappings) {
       if (input[item[from]] !== undefined) {
-        this.data[item[to]] = input[item[from]];
+        this.data[item[to]] = input[item[from]]
       }
     }
-
   }
 
   toJSON() {
-    return this.data;
+    return this.data
   }
 }
 
 class MappableObjectForFront extends MappableObject {
   constructor(input, mappings) {
-    super(input, mappings, 'back', 'front');
+    super(input, mappings, 'back', 'front')
   }
 }
 
 class MappableObjectForBack extends MappableObject {
   constructor(input, mappings) {
-    super(input, mappings, 'front', 'back');
+    super(input, mappings, 'front', 'back')
   }
 }
 
@@ -36,14 +35,16 @@ class MappableObjectForBack extends MappableObject {
  * Use this function to generate a list of fields based on mappings
  */
 function getMappingString(mappings) {
-  let retVal = mappings.map(item => {
-    return item.back;}).join(',');
-  console.log('mapping: ',retVal);
-  return retVal;
+  let retVal = mappings
+    .map((item) => {
+      return item.back
+    })
+    .join(',')
+  return retVal
 }
 
 module.exports = {
   MappableObjectForFront,
   MappableObjectForBack,
-  getMappingString  
-};
+  getMappingString,
+}

--- a/backend/src/util/mapping/Mappings.js
+++ b/backend/src/util/mapping/Mappings.js
@@ -5,7 +5,7 @@ const UserProfileMappings = [
   { back: 'emailaddress1', front: 'email' },
   { back: 'ofm_first_name', front: 'firstName' },
   { back: 'ofm_last_name', front: 'lastName' },
-  { back: 'ofm_portal_role', front: 'role' },
+  { back: 'role', front: 'role' },
   { back: 'telephone1', front: 'phone' },
 ]
 
@@ -83,7 +83,7 @@ const UserMappings = [
   { back: 'emailaddress1', front: 'email' },
   { back: 'telephone1', front: 'phone' },
   { back: 'ccof_username', front: 'userName' },
-  { back: 'ofm_portal_role', front: 'role' },
+  { back: 'role', front: 'role' },
   { back: 'statecode', front: 'stateCode' },
   { back: 'ofm_facility_business_bceid', front: 'facilities' },
 ]
@@ -212,7 +212,7 @@ const ContactMappings = [
   { back: 'ofm_last_name', front: 'lastName' },
   { back: 'telephone1', front: 'phone' },
   { back: 'emailaddress1', front: 'email' },
-  { back: 'ofm_portal_role', front: 'role' },
+  { back: 'role', front: 'role' },
   { back: 'statecode', front: 'stateCode' },
 ]
 
@@ -291,6 +291,17 @@ const SupplementaryApplicationMappings = [
   { back: 'ofm_summary_declaration', front: 'supplementaryDeclaration' },
 ]
 
+const RoleMappings = [
+  { back: 'ofm_name', front: 'roleName' },
+  { back: 'ofm_portal_role_number', front: 'roleNumber' },
+  { back: 'ofm_portal_roleid', front: 'roleId' },
+]
+
+const PermissionMappings = [
+  { back: 'ofm_name', front: 'permissionName' },
+  { back: 'ofm_portal_privilege_number', front: 'permissionNumber' },
+]
+
 module.exports = {
   ApplicationMappings,
   AssistanceRequestMappings,
@@ -304,6 +315,11 @@ module.exports = {
   LicenceDetailsMappings,
   NotificationMappings,
   OrganizationMappings,
+  PermissionMappings,
+  RequestCategoryMappings,
+  RequestSubCategoryMappings,
+  RoleMappings,
+  SupplementaryApplicationMappings,
   UserFacilityDetailMappings,
   UserFacilityMappings,
   UserMappings,
@@ -311,7 +327,4 @@ module.exports = {
   UserProfileFacilityMappings,
   UserProfileMappings,
   UserProfileOrganizationMappings,
-  RequestCategoryMappings,
-  RequestSubCategoryMappings,
-  SupplementaryApplicationMappings,
 }

--- a/frontend/src/components/TheHeader.vue
+++ b/frontend/src/components/TheHeader.vue
@@ -3,9 +3,9 @@
     <!-- Navbar content -->
     <v-container :class="{ sizingForIconXLScreen: xl }" :fluid="true">
       <v-row class="justify-space-between">
-        <a tabindex="-1" href="/">
+        <router-link tabindex="-1" to="{name: 'home'}">
           <img tabindex="-1" src="@/assets/images/bc-gov-logo.svg" class="logo" alt="B.C. Government Logo" />
-        </a>
+        </router-link>
         <v-row class="vertical-line my-auto">
           <v-row class="my-auto">
             <v-toolbar-title fill-height style="font-size: 14px">

--- a/frontend/src/components/TheHeader.vue
+++ b/frontend/src/components/TheHeader.vue
@@ -89,21 +89,28 @@ export default {
       return this.isAuthenticated && this.userInfo && !this.isMinistryUser
     },
   },
-  async created() {
-    try {
-      await this.getUserInfo()
-      if (this.showMessagingIcon) {
-        await this.getNotifications(this.userInfo?.contactId)
-        await this.getAssistanceRequests(this.userInfo?.contactId)
-      }
-    } catch (error) {
-      console.log(error)
-    }
+  watch: {
+    userInfo: {
+      handler(_value) {
+        this.loadUserInfo()
+      },
+      deep: true,
+    },
   },
   methods: {
     ...mapActions(useAuthStore, ['getUserInfo']),
     ...mapActions(useMessagesStore, ['getAssistanceRequests']),
     ...mapActions(useNotificationsStore, ['getNotifications']),
+    async loadUserInfo() {
+      try {
+        if (this.showMessagingIcon) {
+          await this.getNotifications(this.userInfo?.contactId)
+          await this.getAssistanceRequests(this.userInfo?.contactId)
+        }
+      } catch (error) {
+        console.log(error)
+      }
+    },
   },
 }
 </script>

--- a/frontend/src/components/account-mgmt/ManageUserDialog.vue
+++ b/frontend/src/components/account-mgmt/ManageUserDialog.vue
@@ -11,7 +11,16 @@
               <AppLabel for="bceid">BCeID:</AppLabel>
             </v-col>
             <v-col v-if="isAddingUser && !wasNewUserAdded" cols="12" md="9">
-              <v-text-field id="bceid" v-model.trim="user.userName" @blur="checkBCeIDExists(user.userName)" placeholder="BCeID" variant="outlined" density="compact" :rules="rules.required" :error-messages="errorMessages" :disabled="isLoading"></v-text-field>
+              <v-text-field
+                id="bceid"
+                v-model.trim="user.userName"
+                @blur="checkBCeIDExists(user.userName)"
+                placeholder="BCeID"
+                variant="outlined"
+                density="compact"
+                :rules="rules.required"
+                :error-messages="errorMessages"
+                :disabled="isLoading"></v-text-field>
             </v-col>
             <v-col v-else cols="12" md="9" class="mb-5">
               <span>{{ user.userName }}</span>
@@ -46,7 +55,14 @@
               <AppLabel for="email">Email:</AppLabel>
             </v-col>
             <v-col cols="12" md="9">
-              <v-text-field id="email" v-model.trim="user.email" placeholder="user@domain.com" :rules="[rules.email, ...rules.required]" variant="outlined" density="compact" :disabled="isLoading"></v-text-field>
+              <v-text-field
+                id="email"
+                v-model.trim="user.email"
+                placeholder="user@domain.com"
+                :rules="[rules.email, ...rules.required]"
+                variant="outlined"
+                density="compact"
+                :disabled="isLoading"></v-text-field>
             </v-col>
           </v-row>
           <v-row no-gutters>
@@ -56,7 +72,7 @@
             <v-col cols="12" md="9">
               <v-select
                 id="role"
-                :items="userRoles"
+                :items="roles"
                 v-model="user.role"
                 item-title="description"
                 item-value="id"
@@ -172,7 +188,7 @@ export default {
     }
   },
   computed: {
-    ...mapState(useAppStore, ['userRoles']),
+    ...mapState(useAppStore, ['roles']),
     ...mapState(useAuthStore, ['userInfo']),
     isAddingUser() {
       return this.userOperationType === 'add'
@@ -410,7 +426,7 @@ export default {
       try {
         if (this.user.userName) {
           const res = await ApiService.apiAxios.get(`${ApiRoutes.USER}/${userName}?providerProfile=false`)
-          this.errorMessages = (res.data.length >= 1) ? ['A user with this BCeID already exists.'] : []
+          this.errorMessages = res.data.length >= 1 ? ['A user with this BCeID already exists.'] : []
         }
       } catch (error) {
         this.setFailureAlert('Failed to check if BCeID already exists in provider organization: ' + userName, error)
@@ -422,11 +438,13 @@ export default {
      */
     async doesUserExist(firstName, lastName, email) {
       try {
-        const res = await ApiService.apiAxios.get(`${ApiRoutes.ORGANIZATIONS}${ApiRoutes.ORGANIZATIONS_USERS.replace(':organizationId', this.userInfo.organizationId)}?firstName=${firstName}&lastName=${lastName}&email=${email}`);
+        const res = await ApiService.apiAxios.get(
+          `${ApiRoutes.ORGANIZATIONS}${ApiRoutes.ORGANIZATIONS_USERS.replace(':organizationId', this.userInfo.organizationId)}?firstName=${firstName}&lastName=${lastName}&email=${email}`,
+        )
         if (Array.isArray(res.data) && res.data.length >= 1) {
           return true
         }
-        this.errorMessages = [];
+        this.errorMessages = []
         return false
       } catch (error) {
         this.setFailureAlert('Failed to check if user already exists in provider organization', error)
@@ -439,7 +457,6 @@ export default {
     toggleDuplicateUserDialog() {
       this.showDuplicateUserDialog = !this.showDuplicateUserDialog
     },
-
   },
 }
 </script>

--- a/frontend/src/components/account-mgmt/ManageUserDialog.vue
+++ b/frontend/src/components/account-mgmt/ManageUserDialog.vue
@@ -72,7 +72,7 @@
             <v-col cols="12" md="9">
               <v-select
                 id="role"
-                :items="roles"
+                :items="userRoles"
                 v-model="user.role"
                 item-title="description"
                 item-value="id"
@@ -188,7 +188,7 @@ export default {
     }
   },
   computed: {
-    ...mapState(useAppStore, ['roles']),
+    ...mapState(useAppStore, ['userRoles']),
     ...mapState(useAuthStore, ['userInfo']),
     isAddingUser() {
       return this.userOperationType === 'add'

--- a/frontend/src/mixins/permissionsMixin.js
+++ b/frontend/src/mixins/permissionsMixin.js
@@ -1,4 +1,6 @@
-import { useAuthStore } from '../stores/auth'
+import { mapActions } from 'pinia'
+
+import { useAuthStore } from '@/stores/auth'
 import { PERMISSIONS } from '@/utils/constants/permissions.js'
 
 export default {
@@ -7,4 +9,5 @@ export default {
   },
   methods: {
     ...mapActions(useAuthStore, ['hasPermission']),
+  },
 }

--- a/frontend/src/mixins/permissionsMixin.js
+++ b/frontend/src/mixins/permissionsMixin.js
@@ -1,0 +1,10 @@
+import { useAuthStore } from '../stores/auth'
+import { PERMISSIONS } from '@/utils/constants/permissions.js'
+
+export default {
+  created() {
+    this.PERMISSIONS = PERMISSIONS
+  },
+  methods: {
+    ...mapActions(useAuthStore, ['hasPermission']),
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -114,7 +114,6 @@ const router = createRouter({
       component: ReportingView,
       meta: {
         requiresAuth: true,
-        permission: 'Cat Lover',
       },
     },
     {
@@ -358,9 +357,6 @@ router.beforeEach((to, _from, next) => {
                 return next('unauthorized')
               }
               // Validate specific permission
-              if (to.meta.permission) {
-                console.log(`Has ${to.meta.permission}: ${authStore.hasPermission(to.meta.permission)}`)
-              }
               if (to.meta.permission && !authStore.hasPermission(to.meta.permission)) {
                 return next('unauthorized')
               }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -343,8 +343,8 @@ router.beforeEach((to, _from, next) => {
               if (!authStore.hasFacilities) {
                 return next('unauthorized')
               }
-              // Validate specific role
-              if (to.meta.role && !authStore.hasRole(to.meta.role)) {
+              // Validate specific permission
+              if (to.meta.permission && !authStore.hasPermission(to.meta.permission)) {
                 return next('unauthorized')
               }
             }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 
 import { useAuthStore } from '@/stores/auth'
 import { ROLES } from '@/utils/constants'
+import { PERMISSIONS } from '@/utils/constants/permissions.js'
 import BackendSessionExpiredView from '@/views/BackendSessionExpiredView.vue'
 import DocumentsView from '@/views/DocumentsView.vue'
 import ErrorView from '@/views/ErrorView.vue'
@@ -147,6 +148,7 @@ const router = createRouter({
       component: ApplicationsHistoryView,
       meta: {
         requiresAuth: true,
+        permission: PERMISSIONS.VIEW_APPLICATIONS,
       },
     },
     {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -113,6 +113,7 @@ const router = createRouter({
       component: ReportingView,
       meta: {
         requiresAuth: true,
+        permission: 'Cat Lover',
       },
     },
     {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -158,12 +158,16 @@ const router = createRouter({
       redirect: '/applications/select-facility',
       meta: {
         requiresAuth: true,
+        permission: PERMISSIONS.VIEW_APPLICATIONS,
       },
       children: [
         {
           path: 'select-facility',
           name: 'select-facility',
           component: SelectFacilityView,
+          meta: {
+            permission: PERMISSIONS.APPLY_FOR_FUNDING,
+          },
         },
         {
           path: ':applicationGuid/facility-details',
@@ -194,11 +198,17 @@ const router = createRouter({
           path: ':applicationGuid/declare-submit',
           name: 'declare-submit',
           component: DeclareSubmitView,
+          meta: {
+            permission: PERMISSIONS.APPLY_FOR_FUNDING,
+          },
         },
         {
           path: ':applicationGuid/confirmation',
           name: 'application-confirmation',
           component: ApplicationConfirmationView,
+          meta: {
+            permission: PERMISSIONS.APPLY_FOR_FUNDING,
+          },
         },
       ],
     },
@@ -209,6 +219,7 @@ const router = createRouter({
       redirect: { name: 'supp-allowances-form' },
       meta: {
         requiresAuth: true,
+        permission: PERMISSIONS.VIEW_APPLICATIONS,
       },
       children: [
         {
@@ -347,6 +358,9 @@ router.beforeEach((to, _from, next) => {
                 return next('unauthorized')
               }
               // Validate specific permission
+              if (to.meta.permission) {
+                console.log(`Has ${to.meta.permission}: ${authStore.hasPermission(to.meta.permission)}`)
+              }
               if (to.meta.permission && !authStore.hasPermission(to.meta.permission)) {
                 return next('unauthorized')
               }

--- a/frontend/src/stores/app.js
+++ b/frontend/src/stores/app.js
@@ -16,16 +16,15 @@ export const useAppStore = defineStore('app', {
     // Lookup data from Dynamics365
     requestCategories: {},
     requestSubCategories: {},
-    userRoles: {},
+    roles: {},
     healthAuthorities: {},
     facilityTypes: {},
     licenceTypes: {},
-    roles: {},
   }),
   getters: {
     getRoleNameById: (state) => {
       return (id) => {
-        const role = state.userRoles?.find((role) => role.id === id)
+        const role = state.roles?.find((role) => role.id === id)
         return role?.description
       }
     },
@@ -67,11 +66,11 @@ export const useAppStore = defineStore('app', {
         const lookupInfo = await ApiService.getLookupInfo()
         this.requestCategories = lookupInfo?.data?.requestCategories
         this.requestSubCategories = lookupInfo?.data?.requestSubCategories
-        this.userRoles = lookupInfo?.data?.userRoles
+        this.roles = lookupInfo?.data?.roles
         this.healthAuthorities = lookupInfo?.data?.healthAuthorities
         this.facilityTypes = lookupInfo?.data?.facilityTypes
         this.licenceTypes = lookupInfo?.data?.licenceTypes
-        this.roles = lookupInfo?.data?.roles
+        console.log('this.roles', this.roles)
       }
     },
     async setAlertNotificationText(alertNotificationText) {

--- a/frontend/src/stores/app.js
+++ b/frontend/src/stores/app.js
@@ -70,7 +70,6 @@ export const useAppStore = defineStore('app', {
         this.healthAuthorities = lookupInfo?.data?.healthAuthorities
         this.facilityTypes = lookupInfo?.data?.facilityTypes
         this.licenceTypes = lookupInfo?.data?.licenceTypes
-        console.log('this.roles', this.roles)
       }
     },
     async setAlertNotificationText(alertNotificationText) {

--- a/frontend/src/stores/app.js
+++ b/frontend/src/stores/app.js
@@ -16,6 +16,8 @@ export const useAppStore = defineStore('app', {
     // Lookup data from Dynamics365
     requestCategories: {},
     requestSubCategories: {},
+    // TODO (weskubo-cgi) Remove this
+    userRoles: {},
     roles: {},
     healthAuthorities: {},
     facilityTypes: {},
@@ -24,7 +26,7 @@ export const useAppStore = defineStore('app', {
   getters: {
     getRoleNameById: (state) => {
       return (id) => {
-        const role = state.roles?.find((role) => role.id === id)
+        const role = state.userRoles?.find((role) => role.id === id)
         return role?.description
       }
     },
@@ -66,6 +68,7 @@ export const useAppStore = defineStore('app', {
         const lookupInfo = await ApiService.getLookupInfo()
         this.requestCategories = lookupInfo?.data?.requestCategories
         this.requestSubCategories = lookupInfo?.data?.requestSubCategories
+        this.userRoles = lookupInfo?.data?.userRoles
         this.roles = lookupInfo?.data?.roles
         this.healthAuthorities = lookupInfo?.data?.healthAuthorities
         this.facilityTypes = lookupInfo?.data?.facilityTypes

--- a/frontend/src/stores/app.js
+++ b/frontend/src/stores/app.js
@@ -6,11 +6,7 @@ export const useAppStore = defineStore('app', {
   namespaced: true,
   state: () => ({
     // TODO (weskubo-cgi) Remove unused state
-    request: {},
-    selectedRequest: null,
-    messages: [],
     subtitleBanner: '',
-    stickyInfoPanelHeight: null,
 
     // Alert Notifications
     alertNotificationText: '',
@@ -24,7 +20,7 @@ export const useAppStore = defineStore('app', {
     healthAuthorities: {},
     facilityTypes: {},
     licenceTypes: {},
-    config: '',
+    roles: {},
   }),
   getters: {
     getRoleNameById: (state) => {
@@ -75,25 +71,8 @@ export const useAppStore = defineStore('app', {
         this.healthAuthorities = lookupInfo?.data?.healthAuthorities
         this.facilityTypes = lookupInfo?.data?.facilityTypes
         this.licenceTypes = lookupInfo?.data?.licenceTypes
+        this.roles = lookupInfo?.data?.roles
       }
-    },
-    async setConfig(config) {
-      this.config = config
-    },
-    async setRequest(request) {
-      this.request = request || {}
-    },
-    async setSelectedRequest(selectedRequest) {
-      this.selectedRequest = selectedRequest
-    },
-    async pushMessage(message) {
-      this.messages.push(message)
-    },
-    async setMessages(messages) {
-      this.messages = messages || []
-    },
-    async setStickyInfoPanelHeight(stickyInfoPanelHeight) {
-      this.stickyInfoPanelHeight = stickyInfoPanelHeight
     },
     async setAlertNotificationText(alertNotificationText) {
       this.alertNotificationText = alertNotificationText
@@ -105,21 +84,6 @@ export const useAppStore = defineStore('app', {
       this.alertNotificationQueue.push(text)
       if (!this.alertNotification) {
         this.alertNotification = true
-      }
-    },
-    async getConfig() {
-      const response = await ApiService.getConfig()
-      await this.setConfig(response.data)
-    },
-    async refreshEntities() {
-      if (localStorage.getItem('jwtToken')) {
-        // DONT Call api if there is not token.
-        /*TODO: fresh data from backend i.e....
-        const responseActiveSchools = await ApiService.getActiveSchools();
-        await this.setActiveSchools(responseActiveSchools.data);
-        const responseDistricts = await ApiService.getDistricts();
-        await this.setDistricts(responseDistricts.data);
-        */
       }
     },
   },

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -3,6 +3,8 @@ import { defineStore } from 'pinia'
 import ApiService from '@/common/apiService'
 import AuthService from '@/common/authService'
 
+import { useAppStore } from './app'
+
 export const useAuthStore = defineStore('auth', {
   namespaced: true,
   state: () => ({
@@ -17,8 +19,14 @@ export const useAuthStore = defineStore('auth', {
   getters: {
     isActingProvider: (state) => !state.isMinistryUser || state.isImpersonating,
     hasFacilities: (state) => state.userInfo?.facilities?.length > 0,
-    hasRole: (state) => {
-      return (role) => state.userInfo?.role === role
+    // hasRole: (state) => {
+    //   return (role) => state.userInfo?.role === role
+    // },
+    hasPermission: (state) => {
+      return (permission) => {
+        const app = useAppStore()
+        return app.roles.find(state.userInfo?.role)?.permissions.some((rp) => rp === permission)
+      }
     },
   },
   actions: {

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -24,7 +24,8 @@ export const useAuthStore = defineStore('auth', {
       return (role) => state.userInfo?.role === role
     },
     hasPermission: (state) => {
-      return (permission) => state.permissions?.includes(permission)
+      console.log('my permissions', state.permissions)
+      return (permission) => state.permissions.includes(permission)
     },
   },
   actions: {
@@ -77,7 +78,7 @@ export const useAuthStore = defineStore('auth', {
             this.currentFacility = this.userInfo.facilities[0]
           }
           // Lookup the permissions
-          this.permissions = appStore.roles.find((role) => role.roleId === this.userInfo.role)
+          this.permissions = appStore.roles.find((role) => role.roleId === this.userInfo.role.ofm_portal_roleid)?.permissions.map((p) => p.permissionName)
 
           this.isUserInfoLoaded = true
         }

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -24,7 +24,6 @@ export const useAuthStore = defineStore('auth', {
       return (role) => state.userInfo?.role === role
     },
     hasPermission: (state) => {
-      console.log('my permissions', state.permissions)
       return (permission) => state.permissions.includes(permission)
     },
   },

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -25,7 +25,7 @@ export const useAuthStore = defineStore('auth', {
     hasPermission: (state) => {
       return (permission) => {
         const appStore = useAppStore()
-        const matchingRole = appStore.roles.find((role) => role.roleId === state.userInfo.role.ofm_portal_roleid)
+        const matchingRole = appStore.roles.find((role) => role.roleId === state.userInfo.role?.ofm_portal_roleid)
         return matchingRole?.permissions.some((p) => p.permissionName === permission)
       }
     },

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -15,18 +15,16 @@ export const useAuthStore = defineStore('auth', {
     userInfo: null,
     impersonateId: null,
     currentFacility: {},
+    permissions: [],
   }),
   getters: {
     isActingProvider: (state) => !state.isMinistryUser || state.isImpersonating,
     hasFacilities: (state) => state.userInfo?.facilities?.length > 0,
-    // hasRole: (state) => {
-    //   return (role) => state.userInfo?.role === role
-    // },
+    hasRole: (state) => {
+      return (role) => state.userInfo?.role === role
+    },
     hasPermission: (state) => {
-      return (permission) => {
-        const app = useAppStore()
-        return app.roles.find(state.userInfo?.role)?.permissions.some((rp) => rp === permission)
-      }
+      return (permission) => state.permissions?.includes(permission)
     },
   },
   actions: {
@@ -62,6 +60,7 @@ export const useAuthStore = defineStore('auth', {
         await this.getJwtToken()
       }
       if (localStorage.getItem('jwtToken')) {
+        const appStore = useAppStore()
         if (!this.isUserInfoLoaded) {
           let userInfoRes = undefined
           if (this.impersonateId && this.isMinistryUser) {
@@ -77,6 +76,8 @@ export const useAuthStore = defineStore('auth', {
           if (this.isActingProvider && this.hasFacilities) {
             this.currentFacility = this.userInfo.facilities[0]
           }
+          // Lookup the permissions
+          this.permissions = appStore.roles.find((role) => role.roleId === this.userInfo.role)
 
           this.isUserInfoLoaded = true
         }

--- a/frontend/src/utils/constants/permissions.js
+++ b/frontend/src/utils/constants/permissions.js
@@ -1,24 +1,24 @@
 export const PERMISSIONS = Object.freeze({
   // Reporting
-  SEARCH_VIEW_REPORTS:   'Search/View Reports',
+  SEARCH_VIEW_REPORTS: 'Search/View Reports',
   SUBMIT_DRAFT_REPORTS: 'Submit Draft Reports',
   DELETE_DRAFT_REPORTS: 'Delete Draft Reports',
 
   // Funding
-  VIEW_FUNDING_AMOUNTS = 'View Funding Amounts',
-  REQUEST_FUNDING_CHANGE = 'Request Funding Change',
-  VIEW_FUNDING_AGREEMENT = 'View Funding Agreement',
-  SIGN_FUNDING_AGREEMENT = 'Sign Funding Agreement',
+  VIEW_FUNDING_AMOUNTS: 'View Funding Amounts',
+  REQUEST_FUNDING_CHANGE: 'Request Funding Change',
+  VIEW_FUNDING_AGREEMENT: 'View Funding Agreement',
+  SIGN_FUNDING_AGREEMENT: 'Sign Funding Agreement',
 
   // Documents
   DOCUMENT_MANAGEMENT: 'Document Management',
 
   // Application
-  VIEW_APPLICATIONS: 'View ApplicationS',
-  APPLY_FOR_FUNDING: ' Apply for Funding',
+  VIEW_APPLICATIONS: 'View Applications',
+  APPLY_FOR_FUNDING: 'Apply for Funding',
 
   // Resources
-  VIEW_RESOURCES:'View Resources',
+  VIEW_RESOURCES: 'View Resources',
 
   // Account Management
   VIEW_ORG_FACILITY: 'View Org/Facility Information',

--- a/frontend/src/utils/constants/permissions.js
+++ b/frontend/src/utils/constants/permissions.js
@@ -1,0 +1,31 @@
+export const PERMISSIONS = Object.freeze({
+  // Reporting
+  SEARCH_VIEW_REPORTS:   'Search/View Reports',
+  SUBMIT_DRAFT_REPORTS: 'Submit Draft Reports',
+  DELETE_DRAFT_REPORTS: 'Delete Draft Reports',
+
+  // Funding
+  VIEW_FUNDING_AMOUNTS = 'View Funding Amounts',
+  REQUEST_FUNDING_CHANGE = 'Request Funding Change',
+  VIEW_FUNDING_AGREEMENT = 'View Funding Agreement',
+  SIGN_FUNDING_AGREEMENT = 'Sign Funding Agreement',
+
+  // Documents
+  DOCUMENT_MANAGEMENT: 'Document Management',
+
+  // Application
+  VIEW_APPLICATIONS: 'View ApplicationS',
+  APPLY_FOR_FUNDING: ' Apply for Funding',
+
+  // Resources
+  VIEW_RESOURCES:'View Resources',
+
+  // Account Management
+  VIEW_ORG_FACILITY: 'View Org/Facility Information',
+  UPDATE_ORG_FACILITY: 'Update Org/ facility information',
+  SUBMIT_CHANGE_REQUEST: 'Submit Change Request from AM',
+  MANAGE_USERS: 'Manage Users',
+
+  // Notifications and Messages
+  MANAGE_NOTIFICATIONS: 'Manage Notification and Messages',
+})

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -32,7 +32,7 @@
           </v-card-text>
         </v-card>
       </v-col>
-      <v-col cols="12" md="6" lg="4">
+      <v-col cols="12" md="6" lg="4" v-if="hasPermission(PERMISSIONS.VIEW_APPLICATIONS)">
         <v-card class="home-card" prepend-icon="mdi-file-document-multiple-outline" title="Applications" @click="$router.push({ name: 'applications-history' })">
           <v-card-text>
             Etiam nisi erat, dictum finibus arcu feugiat, dictum vestibulum augue. In et auctor urna. Suspendisse potenti. Duis aliquet non ipsum a feugiat. Mauris felis mi, feugiat eu placerat non,
@@ -62,9 +62,12 @@
 <script>
 import OrganizationHeader from '../components/organizations/OrganizationHeader.vue'
 import AppHeroImage from '@/components/ui/AppHeroImage.vue'
+
+import permissionsMixin from '@/mixins/permissionsMixin.js'
 export default {
   name: 'HomeView',
   components: { AppHeroImage, OrganizationHeader },
+  mixins: [permissionsMixin],
 }
 </script>
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -60,10 +60,10 @@
 </template>
 
 <script>
-import OrganizationHeader from '../components/organizations/OrganizationHeader.vue'
+import OrganizationHeader from '@/components/organizations/OrganizationHeader.vue'
 import AppHeroImage from '@/components/ui/AppHeroImage.vue'
-
 import permissionsMixin from '@/mixins/permissionsMixin.js'
+
 export default {
   name: 'HomeView',
   components: { AppHeroImage, OrganizationHeader },

--- a/frontend/src/views/account-mgmt/AccountMgmtView.vue
+++ b/frontend/src/views/account-mgmt/AccountMgmtView.vue
@@ -9,7 +9,7 @@
           </template>
           <router-link :to="{ name: 'manage-organization' }">Manage Organization/Facilities</router-link>
         </v-list-item>
-        <v-list-item v-if="isAccountManager">
+        <v-list-item>
           <template v-slot:prepend>
             <v-icon>mdi-account-group</v-icon>
           </template>
@@ -30,11 +30,6 @@ import { useAuthStore } from '@/stores/auth'
 export default {
   components: { AppBackButton },
   mixins: [rolesMixin],
-  computed: {
-    isAccountManager() {
-      return this.hasRole(this.ROLES.ACCOUNT_MANAGEMENT)
-    },
-  },
   methods: {
     ...mapActions(useAuthStore, ['hasRole']),
   },

--- a/frontend/src/views/applications/ApplicationsHistoryView.vue
+++ b/frontend/src/views/applications/ApplicationsHistoryView.vue
@@ -10,41 +10,47 @@
         Suspendisse tristique fringilla nibh, et vehicula tortor hendrerit a. Etiam nisi erat, dictum finibus arcu feugiat, dictum vestibulum augue. In et auctor urna. Suspendisse potenti.
       </v-col>
     </v-row>
-    <v-row>
-      <v-col class="pb-0 d-flex align-end">
-        <h3>Add New Application</h3>
-      </v-col>
-      <v-col v-if="!hasAValidApplication && !loading" class="pb-0">
-        <v-alert v-if="!hasGoodStanding" type="info" dense text>To apply, you must be in good standing with BC Registries.</v-alert>
-        <v-alert v-else type="info" dense text>If there is no active OFM application, you won't be able to submit a Supplementary Allowance Application.</v-alert>
-      </v-col>
-    </v-row>
-    <v-row>
-      <v-col class="pt-1">
-        <v-card class="home-card justify-center">
-          <v-card-title class="text-center">
-            <v-icon class="mr-2">mdi-file-document-edit-outline</v-icon>
-            OFM Application
-          </v-card-title>
-          <v-card-text class="text-center d-flex flex-column align-center pt-4 pb-0">Before starting an application, verify your organization and facility details in Account Management.</v-card-text>
-          <v-card-actions class="d-flex flex-column align-center">
-            <AppButton id="supp-allowances-button" size="large" width="250px" :to="{ name: 'select-facility' }" class="mt-8 mb-0">Add OFM Application</AppButton>
-          </v-card-actions>
-        </v-card>
-      </v-col>
-      <v-col class="pt-1">
-        <v-card class="home-card justify-center">
-          <v-card-title class="text-center">
-            <v-icon class="mr-2">mdi-file-document-edit-outline</v-icon>
-            Supplementary Allowance Application
-          </v-card-title>
-          <v-card-text class="text-center d-flex flex-column align-center pt-4 pb-0">To apply for Supplementary Funding, you must have an active OFM application for the facility.</v-card-text>
-          <v-card-actions class="d-flex flex-column align-center">
-            <AppButton id="supp-allowances-button" size="large" width="375px" :disabled="!hasAValidApplication" :to="{ name: 'supp-allowances' }" class="mt-8">Add Supplementary Application</AppButton>
-          </v-card-actions>
-        </v-card>
-      </v-col>
-    </v-row>
+    <template v-if="hasPermission(PERMISSIONS.APPLY_FOR_FUNDING)">
+      <v-row>
+        <v-col class="pb-0 d-flex align-end">
+          <h3>Add New Application</h3>
+        </v-col>
+        <v-col v-if="!hasAValidApplication && !loading" class="pb-0">
+          <v-alert v-if="!hasGoodStanding" type="info" dense text>To apply, you must be in good standing with BC Registries.</v-alert>
+          <v-alert v-else type="info" dense text>If there is no active OFM application, you won't be able to submit a Supplementary Allowance Application.</v-alert>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col class="pt-1">
+          <v-card class="home-card justify-center">
+            <v-card-title class="text-center">
+              <v-icon class="mr-2">mdi-file-document-edit-outline</v-icon>
+              OFM Application
+            </v-card-title>
+            <v-card-text class="text-center d-flex flex-column align-center pt-4 pb-0">
+              Before starting an application, verify your organization and facility details in Account Management.
+            </v-card-text>
+            <v-card-actions class="d-flex flex-column align-center">
+              <AppButton id="supp-allowances-button" size="large" width="250px" :to="{ name: 'select-facility' }" class="mt-8 mb-0">Add OFM Application</AppButton>
+            </v-card-actions>
+          </v-card>
+        </v-col>
+        <v-col class="pt-1">
+          <v-card class="home-card justify-center">
+            <v-card-title class="text-center">
+              <v-icon class="mr-2">mdi-file-document-edit-outline</v-icon>
+              Supplementary Allowance Application
+            </v-card-title>
+            <v-card-text class="text-center d-flex flex-column align-center pt-4 pb-0">To apply for Supplementary Funding, you must have an active OFM application for the facility.</v-card-text>
+            <v-card-actions class="d-flex flex-column align-center">
+              <AppButton id="supp-allowances-button" size="large" width="375px" :disabled="!hasAValidApplication" :to="{ name: 'supp-allowances' }" class="mt-8">
+                Add Supplementary Application
+              </AppButton>
+            </v-card-actions>
+          </v-card>
+        </v-col>
+      </v-row>
+    </template>
     <v-row>
       <v-col cols="12" md="5" lg="5" xl="5" class="mt-2">
         <h3>Applications Summary</h3>
@@ -93,6 +99,7 @@
 import AppButton from '@/components/ui/AppButton.vue'
 import AppBackButton from '@/components/ui/AppBackButton.vue'
 import alertMixin from '@/mixins/alertMixin'
+import permissionsMixin from '@/mixins/permissionsMixin'
 import { isEmpty } from 'lodash'
 import format from '@/utils/format'
 import CancelApplicationDialog from '@/components/applications/CancelApplicationDialog.vue'
@@ -106,7 +113,7 @@ import { useOrgStore } from '@/stores/org'
 
 export default {
   components: { AppButton, AppBackButton, CancelApplicationDialog, FacilityFilter },
-  mixins: [alertMixin],
+  mixins: [alertMixin, permissionsMixin],
   data() {
     return {
       format,

--- a/frontend/src/views/applications/FacilityDetailsView.vue
+++ b/frontend/src/views/applications/FacilityDetailsView.vue
@@ -108,11 +108,12 @@ import ContactInfo from '@/components/applications/ContactInfo.vue'
 import ApplicationService from '@/services/applicationService'
 import FacilityService from '@/services/facilityService'
 import alertMixin from '@/mixins/alertMixin'
+import permissionsMixin from '@/mixins/permissionsMixin'
 
 export default {
   name: 'FacilityDetailsView',
   components: { AppLabel, FacilityInfo, ContactInfo },
-  mixins: [alertMixin],
+  mixins: [alertMixin, permissionsMixin],
   async beforeRouteLeave(_to, _from, next) {
     if (!this.readonly) {
       await this.saveApplication()
@@ -153,7 +154,7 @@ export default {
     ...mapState(useApplicationsStore, ['currentApplication', 'validation', 'isApplicationReadonly']),
     ...mapWritableState(useApplicationsStore, ['isFacilityDetailsComplete']),
     readonly() {
-      return this.isApplicationReadonly || this.loading || this.processing
+      return this.isApplicationReadonly || this.loading || this.processing || !this.hasPermission(this.PERMISSIONS.APPLY_FOR_FUNDING)
     },
     // The primary contact cannot be the same as the secondary contact
     availableSecondaryContacts() {

--- a/frontend/src/views/applications/StaffingView.vue
+++ b/frontend/src/views/applications/StaffingView.vue
@@ -133,11 +133,12 @@ import { useApplicationsStore } from '@/stores/applications'
 import { mapState, mapWritableState, mapActions } from 'pinia'
 import ApplicationService from '@/services/applicationService'
 import alertMixin from '@/mixins/alertMixin'
+import permissionsMixin from '@/mixins/permissionsMixin'
 
 export default {
   name: 'StaffingView',
   components: { AppLabel, AppMissingInfoError },
-  mixins: [alertMixin],
+  mixins: [alertMixin, permissionsMixin],
   async beforeRouteLeave(_to, _from, next) {
     if (!this.readonly) {
       await this.saveApplication()
@@ -169,7 +170,7 @@ export default {
     ...mapState(useApplicationsStore, ['currentApplication', 'validation', 'isApplicationReadonly']),
     ...mapWritableState(useApplicationsStore, ['isStaffingComplete']),
     readonly() {
-      return this.isApplicationReadonly || this.processing
+      return this.isApplicationReadonly || this.processing || !this.hasPermission(this.PERMISSIONS.APPLY_FOR_FUNDING)
     },
     totalFullTimePosition() {
       return this.model.staffingInfantECEducatorFullTime + this.model.staffingECEducatorFullTime + this.model.staffingECEducatorAssistantFullTime + this.model.staffingResponsibleAdultFullTime


### PR DESCRIPTION
Initial implementation of permission based security framework. Includes the following:

- Securing a route by permission
- Securing a component (e.g button) by permission
- Using permissions to make a screen read only
- Securing an endpoint by permission by storing the role in the jwt

Known issues:

- There's sometimes a timing issue where the roles (in lookupData) are loaded after the hasPermission check is run. This seems to occur mostly on initial startup of the backend when the values aren't cached. Open to workarounds otherwise will monitor for severity. The query should be much faster in OpenShift so the issue may not appear.

The following is still pending:

- Impersonate roles
- Full security matrix implementation