### PR TITLE
ofmcc-1832 - hide error message for missing Split Classroom description in LicenceDetails for readonly mode

### DIFF
--- a/frontend/src/components/licences/LicenceDetails.vue
+++ b/frontend/src/components/licences/LicenceDetails.vue
@@ -156,7 +156,8 @@
                           variant="outlined"
                           rows="4"
                           :rules="rules.required"
-                          :readonly="readOnly"
+                          :disabled="readOnly"
+                          :hide-details="readOnly"
                           @blur="update(licenceDetail)"></v-textarea>
                       </v-col>
                     </v-row>


### PR DESCRIPTION
Hide error message for missing Split Classroom description in LicenceDetails for readonly mode