### PR TITLE
ofmcc-1874 - update Application/Supp App status mapping

### DIFF
--- a/frontend/src/components/applications/CancelApplicationDialog.vue
+++ b/frontend/src/components/applications/CancelApplicationDialog.vue
@@ -20,7 +20,7 @@
 import AppButton from '@/components/ui/AppButton.vue'
 import AppDialog from '@/components/ui/AppDialog.vue'
 import alertMixin from '@/mixins/alertMixin'
-import { APPLICATION_STATUS_CODES, CRM_STATE_CODES } from '@/utils/constants'
+import { APPLICATION_STATUS_CODES, SUPPLEMENTARY_APPLICATION_STATUS_CODES, CRM_STATE_CODES } from '@/utils/constants'
 import ApplicationService from '@/services/applicationService'
 
 export default {
@@ -68,7 +68,7 @@ export default {
       try {
         this.isLoading = true
         const payload = {
-          statusCode: APPLICATION_STATUS_CODES.CANCELLED_BY_SP,
+          statusCode: this.sourceApplicationType === 'Application' ? APPLICATION_STATUS_CODES.CANCELLED_BY_SP : SUPPLEMENTARY_APPLICATION_STATUS_CODES.CANCELLED,
           stateCode: CRM_STATE_CODES.INACTIVE,
         }
         if (this.applicationType === 'OFM') {

--- a/frontend/src/components/applications/CancelApplicationDialog.vue
+++ b/frontend/src/components/applications/CancelApplicationDialog.vue
@@ -23,6 +23,11 @@ import alertMixin from '@/mixins/alertMixin'
 import { APPLICATION_STATUS_CODES, SUPPLEMENTARY_APPLICATION_STATUS_CODES, CRM_STATE_CODES } from '@/utils/constants'
 import ApplicationService from '@/services/applicationService'
 
+const APPLICATION_TYPES = {
+  APPLICATION: 'Application',
+  SUPP_APPLICATION: 'Supplementary Application',
+}
+
 export default {
   name: 'CancelApplicationDialog',
   components: { AppButton, AppDialog },
@@ -50,7 +55,7 @@ export default {
   },
   computed: {
     sourceApplicationType() {
-      return this.applicationType === 'OFM' ? 'Application' : 'Supplementary Application'
+      return this.applicationType === 'OFM' ? APPLICATION_TYPES.APPLICATION : APPLICATION_TYPES.SUPP_APPLICATION
     },
   },
   watch: {
@@ -68,10 +73,10 @@ export default {
       try {
         this.isLoading = true
         const payload = {
-          statusCode: this.sourceApplicationType === 'Application' ? APPLICATION_STATUS_CODES.CANCELLED_BY_SP : SUPPLEMENTARY_APPLICATION_STATUS_CODES.CANCELLED,
+          statusCode: this.sourceApplicationType === APPLICATION_TYPES.APPLICATION ? APPLICATION_STATUS_CODES.CANCELLED_BY_SP : SUPPLEMENTARY_APPLICATION_STATUS_CODES.CANCELLED,
           stateCode: CRM_STATE_CODES.INACTIVE,
         }
-        if (this.applicationType === 'OFM') {
+        if (this.sourceApplicationType === APPLICATION_TYPES.APPLICATION) {
           await ApplicationService.updateApplication(this.applicationId, payload)
         } else {
           await ApplicationService.updateSupplementaryApplication(this.applicationId, payload)

--- a/frontend/src/components/applications/CancelApplicationDialog.vue
+++ b/frontend/src/components/applications/CancelApplicationDialog.vue
@@ -68,7 +68,7 @@ export default {
       try {
         this.isLoading = true
         const payload = {
-          statusCode: APPLICATION_STATUS_CODES.CANCELLED,
+          statusCode: APPLICATION_STATUS_CODES.CANCELLED_BY_SP,
           stateCode: CRM_STATE_CODES.INACTIVE,
         }
         if (this.applicationType === 'OFM') {

--- a/frontend/src/components/reports/ReportingSearchCard.vue
+++ b/frontend/src/components/reports/ReportingSearchCard.vue
@@ -38,7 +38,7 @@
               <AppLabel>Status(es):</AppLabel>
             </v-col>
             <v-col cols="12" sm="9" lg="8" xl="7">
-              <v-select v-model.lazy="selectedStatuses" :items="STATUS_FILTER_OPTIONS" :disabled="loading" :rules="rules.required" variant="outlined" label="Select Status(s)" chips multiple>
+              <v-select v-model.lazy="selectedStatuses" :items="STATUS_FILTER_OPTIONS" :disabled="loading" :rules="rules.required" variant="outlined" label="Select Status(es)" chips multiple>
                 <template #prepend-item>
                   <v-list-item title="Select All" @click="toggleAllStatuses">
                     <template #prepend>

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -57,11 +57,15 @@ export const ROLES = Object.freeze({
 
 export const APPLICATION_STATUS_CODES = Object.freeze({
   DRAFT: 1,
-  CANCELLED: 2,
+  INELIGIBLE: 2, // INACTIVE state
   SUBMITTED: 3,
   IN_REVIEW: 4,
   AWAITING_PROVIDER: 5,
   APPROVED: 6,
+  CANCELLED_BY_MINISTRY: 7, // INACTIVE state
+  CANCELLED_BY_SP: 8, // INACTIVE state
+  EXPIRED: 9, // INACTIVE state
+  VERIFIED: 10,
 })
 
 export const FUNDING_AGREEMENT_STATUS_CODES = Object.freeze({
@@ -97,11 +101,13 @@ export const DATE_FILTER_TYPES = Object.freeze({
 
 export const SUPPLEMENTARY_APPLICATION_STATUS_CODES = Object.freeze({
   DRAFT: 1,
-  CANCELLED: 2,
+  INELIGIBLE: 2, // INACTIVE state
   SUBMITTED: 3,
   IN_REVIEW: 4,
   ACTION_REQUIRED: 5,
   APPROVED: 6,
+  EXPIRED: 7, // INACTIVE state
+  CANCELLED: 8, // INACTIVE state
 })
 
 export const FACILITY_TYPES = Object.freeze({

--- a/frontend/src/views/applications/ApplicationsHistoryView.vue
+++ b/frontend/src/views/applications/ApplicationsHistoryView.vue
@@ -245,6 +245,7 @@ export default {
       // Applications' funding agreements are used in applications validation to enable the Add Supplementary Application button
       await Promise.all(
         this.applications?.map(async (application) => {
+          application.status = application.statusCode === APPLICATION_STATUS_CODES.VERIFIED ? 'In Review' : application.status
           application.fundingAgreement = await FundingAgreementService.getActiveFundingAgreementByApplicationId(application.applicationId)
         }),
       )
@@ -325,9 +326,13 @@ export default {
       if (this.DRAFT_STATUS_CODES.includes(statusCode)) {
         return 'status-gray'
       } else if (
-        [APPLICATION_STATUS_CODES.IN_REVIEW, SUPPLEMENTARY_APPLICATION_STATUS_CODES.IN_REVIEW, APPLICATION_STATUS_CODES.SUBMITTED, SUPPLEMENTARY_APPLICATION_STATUS_CODES.SUBMITTED].includes(
-          statusCode,
-        )
+        [
+          APPLICATION_STATUS_CODES.VERIFIED,
+          APPLICATION_STATUS_CODES.IN_REVIEW,
+          SUPPLEMENTARY_APPLICATION_STATUS_CODES.IN_REVIEW,
+          APPLICATION_STATUS_CODES.SUBMITTED,
+          SUPPLEMENTARY_APPLICATION_STATUS_CODES.SUBMITTED,
+        ].includes(statusCode)
       ) {
         return 'status-green'
       } else if ([APPLICATION_STATUS_CODES.APPROVED, SUPPLEMENTARY_APPLICATION_STATUS_CODES.APPROVED].includes(statusCode)) {


### PR DESCRIPTION
In Application History page:
- For Core application, display Verified status as “In Review”
- If the user cancels a Core application from the Portal, that application will be deactivated in CRM and set to “Cancelled by SP” in CRM
- If the user cancels a Supplementary application from the Portal, that application will be deactivated in CRM and set to “Cancelled” in CRM