### PR TITLE
update Funding Agreements to always return the newest FA or MOD

### DIFF
--- a/backend/src/components/fundingAgreements.js
+++ b/backend/src/components/fundingAgreements.js
@@ -10,12 +10,13 @@ const { isEmpty } = require('lodash')
 async function getFundingAgreements(req, res) {
   try {
     const fundingAgreements = []
-    let operation = 'ofm_fundings?$select=ofm_fundingid,ofm_funding_number,ofm_declaration,ofm_start_date,ofm_end_date,_ofm_application_value,_ofm_facility_value,statuscode,statecode'
+    let operation =
+      'ofm_fundings?$select=ofm_fundingid,ofm_funding_number,ofm_declaration,ofm_start_date,ofm_end_date,_ofm_application_value,_ofm_facility_value,statuscode,statecode,ofm_version_number'
     if (req.query?.includeEA) {
       operation += '&$expand=ofm_application($select=_ofm_expense_authority_value;$expand=ofm_expense_authority($select=ofm_first_name,ofm_last_name))'
     }
     const filter = `${buildDateFilterQuery(req?.query, 'ofm_start_date')}${buildFilterQuery(req?.query, FundingAgreementMappings)}`
-    operation += `&$filter=(${filter})`
+    operation += `&$filter=(${filter})&$orderby=ofm_version_number desc`
     const response = await getOperation(operation)
     response?.value?.forEach((funding) => {
       const fa = new MappableObjectForFront(funding, FundingAgreementMappings).toJSON()

--- a/backend/src/components/fundingAgreements.js
+++ b/backend/src/components/fundingAgreements.js
@@ -10,8 +10,7 @@ const { isEmpty } = require('lodash')
 async function getFundingAgreements(req, res) {
   try {
     const fundingAgreements = []
-    let operation =
-      'ofm_fundings?$select=ofm_fundingid,ofm_funding_number,ofm_declaration,ofm_start_date,ofm_end_date,_ofm_application_value,_ofm_facility_value,statuscode,statecode,ofm_version_number'
+    let operation = 'ofm_fundings?$select=ofm_fundingid,ofm_funding_number,ofm_declaration,ofm_start_date,ofm_end_date,_ofm_application_value,_ofm_facility_value,statuscode,statecode'
     if (req.query?.includeEA) {
       operation += '&$expand=ofm_application($select=_ofm_expense_authority_value;$expand=ofm_expense_authority($select=ofm_first_name,ofm_last_name))'
     }

--- a/frontend/src/services/fundingAgreementService.js
+++ b/frontend/src/services/fundingAgreementService.js
@@ -2,11 +2,16 @@ import ApiService from '@/common/apiService'
 import { ApiRoutes, CRM_STATE_CODES } from '@/utils/constants'
 
 export default {
-  async getActiveFundingAgreementByApplicationId(applicationId) {
+  async getActiveFundingAgreementByApplicationId(applicationId, ignoreMODAgreements = false) {
     try {
       if (!applicationId) return
       const response = await ApiService.apiAxios.get(`${ApiRoutes.FUNDING_AGREEMENTS}?applicationId=${applicationId}&stateCode=${CRM_STATE_CODES.ACTIVE}`)
-      //CRM confirmed that there will only ever be one Funding Agreement per ApplicationID. However response returns an array. If index 0 contains data, return it
+
+      //Node.js will order FA's so newest one (newest MOD agreement) will always be first
+      //in the case of Supp Apps - we will need the start date of the ORIGINAL funding agreement - so take the last FA in the list
+      if (ignoreMODAgreements) {
+        return response?.data[response.data.length - 1]
+      }
       return response?.data[0]
     } catch (error) {
       console.log(`Failed to get the active funding agreement by application id - ${error}`)
@@ -47,19 +52,7 @@ export default {
     }
   },
 
-  // A facility can have only 1 Active funding agreement
-  async getActiveFundingAgreementByFacilityId(facilityId) {
-    try {
-      if (!facilityId) return
-      const response = await ApiService.apiAxios.get(`${ApiRoutes.FUNDING_AGREEMENTS}?facilityId=${facilityId}&stateCode=${CRM_STATE_CODES.ACTIVE}`)
-      return response?.data[0]
-    } catch (error) {
-      console.log(`Failed to get the active funding agreement by facility id - ${error}`)
-      throw error
-    }
-  },
-
-  // A facility can have only 1 Active funding agreement
+  //Node.js will order FA's so newest one (newest MOD agreement) will always be first
   async getActiveFundingAgreementByFacilityIdAndStatus(facilityId, statusCode) {
     try {
       if (!facilityId && !statusCode) return

--- a/frontend/src/views/supp-allowances/SupplementaryAllowanceView.vue
+++ b/frontend/src/views/supp-allowances/SupplementaryAllowanceView.vue
@@ -140,7 +140,7 @@ export default {
         // navigate from the Application Confirmation page (after the providers have just submitted their core funding application)
         if (this.$route.params.applicationGuid) {
           this.application = await ApplicationService.getApplication(this.$route.params.applicationGuid)
-          this.application.fundingAgreement = await FundingAgreementService.getActiveFundingAgreementByApplicationId(this.$route.params.applicationGuid)
+          this.application.fundingAgreement = await FundingAgreementService.getActiveFundingAgreementByApplicationId(this.$route.params.applicationGuid, true)
         }
         // navigate from the Application History page
         else {
@@ -148,7 +148,7 @@ export default {
           this.applications = this.applications?.filter((application) => ApplicationService.checkApplicationStatus(application))
           await Promise.all(
             this.applications?.map(async (application) => {
-              application.fundingAgreement = await FundingAgreementService.getActiveFundingAgreementByApplicationId(application.applicationId)
+              application.fundingAgreement = await FundingAgreementService.getActiveFundingAgreementByApplicationId(application.applicationId, true)
             }),
           )
           this.facilities = this.userInfo?.facilities?.filter((facility) => this.getValidApplication(facility.facilityId))

--- a/frontend/src/views/supp-allowances/SupplementarySubmitView.vue
+++ b/frontend/src/views/supp-allowances/SupplementarySubmitView.vue
@@ -238,7 +238,7 @@ export default {
         //this page should specifiy to load only those applications in "draft" status - as there will be
         //scenarios where some applications have been submitted, but the user will want to come back and fill in others.
         this.models = await ApplicationService.getSupplementaryApplications(this.$route.params.applicationGuid)
-        this.fundingAgreement = await FundingAgreementService.getActiveFundingAgreementByApplicationId(this.$route.params.applicationGuid)
+        this.fundingAgreement = await FundingAgreementService.getActiveFundingAgreementByApplicationId(this.$route.params.applicationGuid, true)
 
         this.setSuppTermDates()
         //we need submitted transport applications to verify that all VINs are unique, even in past applications


### PR DESCRIPTION
-- removed function getActiveFundingAgreementByFacilityId(facilityId) as it does not appear to be used anywhere 

always return the newest version (either the original Funding Agreement or MOD) that is active, unless being used for Supp Apps, in which case return the original FA. This is being updated here to support the backdate Transport App functionality (ofm 4772)