### PR TITLE
fix: breaking changes from 4.16

### DIFF
--- a/.github/workflows/deploy-to-openshift-backend-dev.yml
+++ b/.github/workflows/deploy-to-openshift-backend-dev.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   openshift-ci-cd:
     name: Build and deploy Backend to DEV
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: dev
 
     outputs:

--- a/.github/workflows/deploy-to-openshift-backend-test.yml
+++ b/.github/workflows/deploy-to-openshift-backend-test.yml
@@ -44,7 +44,7 @@ on:
 jobs:
   openshift-ci-cd:
     name: Deploy Backend to TEST
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: test
 
     outputs:

--- a/.github/workflows/deploy-to-openshift-backend-uat.yml
+++ b/.github/workflows/deploy-to-openshift-backend-uat.yml
@@ -46,7 +46,6 @@ jobs:
   openshift-ci-cd:
     name: Deploy Backend to UAT
     runs-on: ubuntu-24.04
-    
     environment: uat
 
     outputs:

--- a/.github/workflows/deploy-to-openshift-backend-uat.yml
+++ b/.github/workflows/deploy-to-openshift-backend-uat.yml
@@ -45,7 +45,8 @@ on:
 jobs:
   openshift-ci-cd:
     name: Deploy Backend to UAT
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    
     environment: uat
 
     outputs:

--- a/.github/workflows/deploy-to-openshift-frontend-test.yml
+++ b/.github/workflows/deploy-to-openshift-frontend-test.yml
@@ -52,7 +52,7 @@ on:
 jobs:
   openshift-ci-cd:
     name: Deploy Frontend to TEST
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: test
 
     outputs:

--- a/.github/workflows/deploy-to-openshift-frontend-uat.yml
+++ b/.github/workflows/deploy-to-openshift-frontend-uat.yml
@@ -53,7 +53,7 @@ on:
 jobs:
   openshift-ci-cd:
     name: Deploy Frontend to UAT
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: uat
 
     outputs:


### PR DESCRIPTION
OpenShift cli needs a newer version of GCC in order to work.  We have updated the Ubuntu container for deployment to the latest LTS (24.04)