### PR TITLE
OFMCC-3478 - Handle refresh issue

### DIFF
--- a/frontend/src/components/messages/NewRequestDialog.vue
+++ b/frontend/src/components/messages/NewRequestDialog.vue
@@ -281,7 +281,7 @@
       :show="showNewRequestConfirmationDialog"
       :isInvokedFromMessages="isInvokedFromMessages"
       :return-to="returnTo"
-      @close="toggleNewRequestConfirmationDialog" />
+      @close="handleCloseConfirmationDialog" />
   </v-container>
 </template>
 
@@ -349,7 +349,7 @@ export default {
       default: 'home',
     },
   },
-  emits: ['close'],
+  emits: ['close', 'close-confirmation'],
   data() {
     return {
       isFormComplete: false,
@@ -657,6 +657,11 @@ export default {
           this.isLoading = false
         }
       }
+    },
+
+    handleCloseConfirmationDialog() {
+      this.toggleNewRequestConfirmationDialog()
+      this.$emit('close-confirmation')
     },
 
     toggleNewRequestConfirmationDialog() {

--- a/frontend/src/views/account-mgmt/ManageFacilityView.vue
+++ b/frontend/src/views/account-mgmt/ManageFacilityView.vue
@@ -139,36 +139,35 @@
       :show="showChangeRequestDialog"
       :defaultRequestCategoryId="getRequestCategoryIdByName(REQUEST_CATEGORY_NAMES.ACCOUNT_MAINTENANCE)"
       :defaultFacility="facility"
-      @close="toggleChangeRequestDialog" />
+      @close="toggleChangeRequestDialog"
+      @close-confirmation="handleCloseConfirmation" />
     <UnableToSubmitCrDialog :show="showUnableToSubmitCrDialog" :displayType="preventChangeRequestType" @close="toggleUnableToSubmitCrDialog" />
   </v-container>
 </template>
 
 <script>
-import AppButton from '@/components/ui/AppButton.vue'
+import { isEmpty } from 'lodash'
+import { mapState } from 'pinia'
+
 import AppBackButton from '@/components/ui/AppBackButton.vue'
+import AppButton from '@/components/ui/AppButton.vue'
 import AppLabel from '@/components/ui/AppLabel.vue'
 import alertMixin from '@/mixins/alertMixin'
 import permissionsMixin from '@/mixins/permissionsMixin'
-import rules from '@/utils/rules'
-import { ApiRoutes } from '@/utils/constants'
-import { useAppStore } from '@/stores/app'
-import { mapState } from 'pinia'
-import { useAuthStore } from '@/stores/auth'
-import ApiService from '@/common/apiService'
+import EditFacilityContacts from '@/components/account-mgmt/EditFacilityContacts.vue'
+import UnableToSubmitCrDialog from '@/components/account-mgmt/UnableToSubmitCrDialog.vue'
+import ContactInfo from '@/components/applications/ContactInfo.vue'
+import FacilityInfo from '@/components/facilities/FacilityInfo.vue'
+import LicenceDetails from '@/components/licences/LicenceDetails.vue'
+import LicenceHeader from '@/components/licences/LicenceHeader.vue'
+import NewRequestDialog from '@/components/messages/NewRequestDialog.vue'
 import ApplicationService from '@/services/applicationService'
 import FacilityService from '@/services/facilityService'
 import LicenceService from '@/services/licenceService'
-import FacilityInfo from '@/components/facilities/FacilityInfo.vue'
-import EditFacilityContacts from '@/components/account-mgmt/EditFacilityContacts.vue'
-import ContactInfo from '@/components/applications/ContactInfo.vue'
-import LicenceHeader from '@/components/licences/LicenceHeader.vue'
-import LicenceDetails from '@/components/licences/LicenceDetails.vue'
-import NewRequestDialog from '@/components/messages/NewRequestDialog.vue'
-import UnableToSubmitCrDialog from '@/components/account-mgmt/UnableToSubmitCrDialog.vue'
+import { useAppStore } from '@/stores/app'
+import { useAuthStore } from '@/stores/auth'
 import { REQUEST_CATEGORY_NAMES, OFM_PROGRAM_CODES, PREVENT_CHANGE_REQUEST_TYPES } from '@/utils/constants'
-
-import { isEmpty } from 'lodash'
+import rules from '@/utils/rules'
 
 export default {
   name: 'ManageFacilityView',
@@ -389,6 +388,10 @@ export default {
      */
     toggleChangeRequestDialog() {
       this.showChangeRequestDialog = !this.showChangeRequestDialog
+    },
+
+    handleCloseConfirmation() {
+      this.loadData()
     },
 
     async validateOfmProgram() {

--- a/frontend/src/views/account-mgmt/ManageOrganizationView.vue
+++ b/frontend/src/views/account-mgmt/ManageOrganizationView.vue
@@ -71,7 +71,8 @@
       class="pa-0"
       :show="showChangeRequestDialog"
       :defaultRequestCategoryId="getRequestCategoryIdByName(REQUEST_CATEGORY_NAMES.ACCOUNT_MAINTENANCE)"
-      @close="toggleChangeRequestDialog" />
+      @close="toggleChangeRequestDialog"
+      @close-confirmation="handleCloseConfirmation" />
     <UnableToSubmitCrDialog :show="showUnableToSubmitCrDialog" :displayType="preventChangeRequestType" @close="toggleUnableToSubmitCrDialog" />
   </v-container>
 </template>
@@ -183,6 +184,10 @@ export default {
      */
     toggleChangeRequestDialog() {
       this.showChangeRequestDialog = !this.showChangeRequestDialog
+    },
+
+    handleCloseConfirmation() {
+      this.loadData()
     },
 
     async validateOfmProgram() {


### PR DESCRIPTION
- Added emit to allow logic on close. For Facility/Org this means we can refresh the data
- I did not leverage the custom navigation logic added by Viet as I didn't want to impact the existing functionality of the screen. Also the "Return to foo" button label won't work for these screen titles.