### PR TITLE
Ofmcc 5789 transport validation enhancement

### DIFF
--- a/frontend/src/components/supp-allowances/TransportationAllowance.vue
+++ b/frontend/src/components/supp-allowances/TransportationAllowance.vue
@@ -83,7 +83,7 @@
                 <AppNumberInput
                   v-model="model.odometer"
                   required
-                  :format="wholeNumberNonZeroFormat"
+                  :format="wholeNumberFormat"
                   suffix="km"
                   variant="outlined"
                   density="compact"
@@ -101,7 +101,7 @@
                 <AppNumberInput
                   v-model="model.estimatedMileage"
                   required
-                  :format="wholeNumberNonZeroFormat"
+                  :format="wholeNumberFormat"
                   suffix="km"
                   variant="outlined"
                   density="compact"
@@ -227,7 +227,7 @@ export default {
         separator: ',',
         precision: 2,
       },
-      wholeNumberNonZeroFormat: {
+      wholeNumberFormat: {
         nullValue: '',
         precision: 0,
       },

--- a/frontend/src/components/supp-allowances/TransportationAllowance.vue
+++ b/frontend/src/components/supp-allowances/TransportationAllowance.vue
@@ -85,8 +85,6 @@
                   required
                   :format="wholeNumberFormat"
                   suffix="km"
-                  variant="outlined"
-                  density="compact"
                   :rules="[rules.max(999999), rules.min(1), ...rules.required]"
                   :disabled="readOnly(model)"></AppNumberInput>
               </v-col>
@@ -103,8 +101,6 @@
                   required
                   :format="wholeNumberFormat"
                   suffix="km"
-                  variant="outlined"
-                  density="compact"
                   :rules="[rules.max(999999), rules.min(1), ...rules.required]"
                   :disabled="readOnly(model)"></AppNumberInput>
               </v-col>

--- a/frontend/src/components/supp-allowances/TransportationAllowance.vue
+++ b/frontend/src/components/supp-allowances/TransportationAllowance.vue
@@ -82,7 +82,6 @@
               <v-col cols="6" xl="7" class="pt-2 text-center">
                 <AppNumberInput
                   v-model="model.odometer"
-                  required
                   :format="wholeNumberFormat"
                   suffix="km"
                   :rules="[rules.max(999999), rules.min(1), ...rules.required]"
@@ -98,7 +97,6 @@
               <v-col cols="6" xl="7" class="pt-2 text-center">
                 <AppNumberInput
                   v-model="model.estimatedMileage"
-                  required
                   :format="wholeNumberFormat"
                   suffix="km"
                   :rules="[rules.max(999999), rules.min(1), ...rules.required]"

--- a/frontend/src/components/supp-allowances/TransportationAllowance.vue
+++ b/frontend/src/components/supp-allowances/TransportationAllowance.vue
@@ -80,15 +80,15 @@
                 <p>Vehicle mileage at time of application (odometer reading):</p>
               </v-col>
               <v-col cols="6" xl="7" class="pt-2 text-center">
-                <v-text-field
+                <AppNumberInput
                   v-model="model.odometer"
                   required
-                  type="number"
+                  :format="wholeNumberNonZeroFormat"
                   suffix="km"
                   variant="outlined"
                   density="compact"
-                  :rules="[rules.max(999999), ...rules.required]"
-                  :disabled="readOnly(model)"></v-text-field>
+                  :rules="[rules.max(999999), rules.min(1), ...rules.required]"
+                  :disabled="readOnly(model)"></AppNumberInput>
               </v-col>
             </v-row>
           </v-col>
@@ -98,15 +98,15 @@
                 <p>Estimated Yearly KM:</p>
               </v-col>
               <v-col cols="6" xl="7" class="pt-2 text-center">
-                <v-text-field
+                <AppNumberInput
                   v-model="model.estimatedMileage"
                   required
-                  type="number"
+                  :format="wholeNumberNonZeroFormat"
                   suffix="km"
                   variant="outlined"
                   density="compact"
-                  :rules="[rules.max(999999), ...rules.required]"
-                  :disabled="readOnly(model)"></v-text-field>
+                  :rules="[rules.max(999999), rules.min(1), ...rules.required]"
+                  :disabled="readOnly(model)"></AppNumberInput>
               </v-col>
             </v-row>
           </v-col>
@@ -226,6 +226,10 @@ export default {
         decimal: '.',
         separator: ',',
         precision: 2,
+      },
+      wholeNumberNonZeroFormat: {
+        nullValue: '',
+        precision: 0,
       },
     }
   },

--- a/frontend/src/utils/rules.js
+++ b/frontend/src/utils/rules.js
@@ -36,7 +36,7 @@ const rules = {
     return (v) => !v || v <= number || `Max exceeded: ${number.toLocaleString('en-ca')}`
   },
   min(number) {
-    return (v) => !v || v >= number || `Number must be at least: ${number.toLocaleString('en-ca')}`
+    return (v) => !v || v >= number || `Please enter a number greater than  ${(number - 1).toLocaleString('en-ca')}  in the field`
   },
   maxLength(number) {
     return (v) => !v || v.length <= number || 'Max length exceeded'

--- a/frontend/src/utils/rules.js
+++ b/frontend/src/utils/rules.js
@@ -36,7 +36,7 @@ const rules = {
     return (v) => !v || v <= number || `Max exceeded: ${number.toLocaleString('en-ca')}`
   },
   min(number) {
-    return (v) => !v || v >= number || `Min exceeded: ${number.toLocaleString('en-ca')}`
+    return (v) => !v || v >= number || `Number must be at least: ${number.toLocaleString('en-ca')}`
   },
   maxLength(number) {
     return (v) => !v || v.length <= number || 'Max length exceeded'

--- a/frontend/src/views/supp-allowances/SupplementaryFormView.vue
+++ b/frontend/src/views/supp-allowances/SupplementaryFormView.vue
@@ -250,11 +250,12 @@ export default {
       async handler() {
         if (this.transportAppsHaveZero) {
           await this.$refs.form?.validate()
+          return
         } else if (this.hasPermission(this.PERMISSIONS.APPLY_FOR_FUNDING)) {
           await this.saveApplication()
-          const applicationId = this.applicationId ? this.applicationId : this.$route.params.applicationGuid
-          this.$router.push({ name: 'supp-allowances-submit', params: { applicationGuid: applicationId } })
         }
+        const applicationId = this.applicationId ? this.applicationId : this.$route.params.applicationGuid
+        this.$router.push({ name: 'supp-allowances-submit', params: { applicationGuid: applicationId } })
       },
     },
   },

--- a/frontend/src/views/supp-allowances/SupplementaryFormView.vue
+++ b/frontend/src/views/supp-allowances/SupplementaryFormView.vue
@@ -491,12 +491,26 @@ export default {
       this.showCancelDialog = !this.showCancelDialog
     },
     setNext() {
+      console.log('called')
+      console.log(this.models)
+      let int = 0
       this.$emit(
         'setNext',
         this.models.every((el) => {
-          if (el.statusCode && isApplicationLocked(el.statusCode)) {
+          int++
+          console.log('rounds ', int)
+          //console.log(el)
+
+          console.log(el.supplementaryType)
+          if (el.supplementaryType === SUPPLEMENTARY_TYPES.TRANSPORT) {
+            // console.log(el.odometer)
+            // console.log(el.estimatedMileage)
+            // console.log(!el.odometer && !el.estimatedMileage)
+            return el.odometer && el.estimatedMileage
+          } else if (el.statusCode && isApplicationLocked(el.statusCode)) {
             return true
           }
+          console.log('is empty ,', this.isModelEmpty(el))
           return this.isModelEmpty(el)
         }),
       )


### PR DESCRIPTION
Changed the messaging in 'rules' for the min value -- currently this PR is the only files that use that error message, so I don't think there should be an impact there 

Prevent save / next if user enters '0' on some fields on Transport App. I purposefully did not set the 'min' value on format to 1 - because it becomes annoying if a user wants to type in a different number that does not start with one. 

Works with both current and next year scenarios 