### PR TITLE
Ofmcc 5412 ee updates

### DIFF
--- a/backend/src/components/applications.js
+++ b/backend/src/components/applications.js
@@ -38,7 +38,7 @@ function mapSupplementaryApplicationObjectForFront(data) {
 async function getApplications(req, res) {
   try {
     const applications = []
-    const operation = `ofm_applications?$select=ofm_application,ofm_summary_ministry_last_updated,ofm_summary_provider_last_updated,ofm_summary_submittedon,statuscode,statecode,_ofm_facility_value&$filter=(${buildFilterQuery(
+    const operation = `ofm_applications?$select=ofm_application,ofm_summary_ministry_last_updated,ofm_summary_provider_last_updated,ofm_summary_submittedon,statuscode,statecode,ofm_unionized,_ofm_facility_value&$filter=(${buildFilterQuery(
       req?.query,
       ApplicationMappings,
     )})`

--- a/backend/src/util/mapping/Mappings.js
+++ b/backend/src/util/mapping/Mappings.js
@@ -246,6 +246,7 @@ const FacilityMappings = [
   { back: 'ofm_ypp_designation', front: 'yppDesignation' },
   { back: 'ofm_ypp_enrolled', front: 'yppEnrolled' },
   { back: 'ofm_personal_residence', front: 'personalResidence' },
+  { back: 'ofm_unionized', front: 'isUnionized' },
 ]
 
 const ContactMappings = [

--- a/backend/src/util/mapping/Mappings.js
+++ b/backend/src/util/mapping/Mappings.js
@@ -28,6 +28,7 @@ const UserProfileFacilityMappings = [
   { back: 'ofm_program_start_date', front: 'programStartDate' },
   { back: 'statecode', front: 'facilityStateCode' },
   { back: 'statuscode', front: 'facilityStatusCode' },
+  { back: 'ofm_unionized', front: 'isUnionized' },
 ]
 
 const RequestCategoryMappings = [

--- a/frontend/src/components/messages/NewRequestDialog.vue
+++ b/frontend/src/components/messages/NewRequestDialog.vue
@@ -502,7 +502,7 @@ export default {
     },
     filteredFacilties() {
       if (this.isIrregularExpenseRequest) {
-        return this.facilities.filter((fac) => this.fundingAgreements.some((app) => app?.facilityId === fac?.facilityId))
+        return this.facilities.filter((fac) => this.fundingAgreements.some((app) => app?.facilityId === fac?.facilityId) && fac?.isUnionized === 0)
       }
       return this.facilities
     },
@@ -836,6 +836,11 @@ export default {
             const fa = await FundingAgreementService.getActiveFundingAgreementByFacilityIdAndStatus(facility.facilityId, FUNDING_AGREEMENT_STATUS_CODES.ACTIVE)
             if (fa) {
               this.fundingAgreements.push(fa)
+              const additionalFacilityInfo = await FacilityService.getFacility(facility.facilityId)
+
+              facility.isUnionized = additionalFacilityInfo?.isUnionized
+            } else {
+              facility.isUnionized = null
             }
           }),
         )

--- a/frontend/src/components/messages/NewRequestDialog.vue
+++ b/frontend/src/components/messages/NewRequestDialog.vue
@@ -837,7 +837,6 @@ export default {
             if (fa) {
               this.fundingAgreements.push(fa)
               const additionalFacilityInfo = await FacilityService.getFacility(facility.facilityId)
-
               facility.isUnionized = additionalFacilityInfo?.isUnionized
             } else {
               facility.isUnionized = null

--- a/frontend/src/components/messages/NewRequestDialog.vue
+++ b/frontend/src/components/messages/NewRequestDialog.vue
@@ -836,10 +836,6 @@ export default {
             const fa = await FundingAgreementService.getActiveFundingAgreementByFacilityIdAndStatus(facility.facilityId, FUNDING_AGREEMENT_STATUS_CODES.ACTIVE)
             if (fa) {
               this.fundingAgreements.push(fa)
-              const additionalFacilityInfo = await FacilityService.getFacility(facility.facilityId)
-              facility.isUnionized = additionalFacilityInfo?.isUnionized
-            } else {
-              facility.isUnionized = null
             }
           }),
         )

--- a/frontend/src/components/messages/NewRequestDialog.vue
+++ b/frontend/src/components/messages/NewRequestDialog.vue
@@ -306,6 +306,7 @@ import { mapState, mapActions } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
 import { useAppStore } from '@/stores/app'
 import { useMessagesStore } from '@/stores/messages'
+import { useOrgStore } from '@/stores/org'
 import AppButton from '@/components/ui/AppButton.vue'
 import AppDialog from '@/components/ui/AppDialog.vue'
 import AppLabel from '@/components/ui/AppLabel.vue'
@@ -324,7 +325,7 @@ import MessageService from '@/services/messageService'
 import OrganizationService from '@/services/organizationService'
 import FundingAgreementService from '@/services/fundingAgreementService'
 import { ASSISTANCE_REQUEST_STATUS_CODES, CRM_STATE_CODES, OFM_PROGRAM_CODES, PREVENT_CHANGE_REQUEST_TYPES } from '@/utils/constants'
-import { REQUEST_CATEGORY_NAMES, REQUEST_SUB_CATEGORY_NAMES, PHONE_FORMAT, EMAIL_FORMAT, VIRUS_SCAN_ERROR_MESSAGE, FUNDING_AGREEMENT_STATUS_CODES } from '@/utils/constants'
+import { REQUEST_CATEGORY_NAMES, REQUEST_SUB_CATEGORY_NAMES, PHONE_FORMAT, EMAIL_FORMAT, VIRUS_SCAN_ERROR_MESSAGE, FUNDING_AGREEMENT_STATUS_CODES, PROVIDER_TYPE_CODES } from '@/utils/constants'
 
 export default {
   name: 'NewRequestDialog',
@@ -396,6 +397,7 @@ export default {
   computed: {
     ...mapState(useAppStore, ['requestCategories', 'requestSubCategories', 'getRequestCategoryIdByName', 'getRequestSubCategoryIdByName']),
     ...mapState(useAuthStore, ['currentFacility', 'userInfo']),
+    ...mapState(useOrgStore, ['currentOrg']),
     permittedRequestCategories() {
       let categories = [...this.requestCategories]
 
@@ -502,6 +504,10 @@ export default {
     },
     filteredFacilties() {
       if (this.isIrregularExpenseRequest) {
+        //family org can never apply for irregular expense
+        if (this.currentOrg?.providerType === PROVIDER_TYPE_CODES.FAMILY) {
+          return []
+        }
         return this.facilities.filter((fac) => this.fundingAgreements.some((app) => app?.facilityId === fac?.facilityId) && fac?.isUnionized === 0)
       }
       return this.facilities
@@ -550,6 +556,9 @@ export default {
         if (this.isIrregularExpenseRequest && !this.fundingAgreements) {
           this.isLoading = true
           await this.getFundingAgreements()
+          if (!this.currentOrg) {
+            await this.getOrganizationInfo(this.userInfo?.organizationId)
+          }
           this.isLoading = false
         }
         this.resetModelData(this.isAccountMaintenanceRequest)
@@ -587,6 +596,7 @@ export default {
   },
   methods: {
     ...mapActions(useMessagesStore, ['addNewAssistanceRequestToStore', 'updateAssistanceRequestInStore']),
+    ...mapActions(useOrgStore, ['getOrganizationInfo']),
 
     //this function runs to check if the selected facility is able to submit certain kinds of assitance requests.
     //it is only available to Account Managers and should only be called if the correct checkbox(es) are selected

--- a/frontend/src/components/supp-allowances/IndigenousProgrammingAllowance.vue
+++ b/frontend/src/components/supp-allowances/IndigenousProgrammingAllowance.vue
@@ -1,5 +1,5 @@
 <template>
-  <AppAlertBanner v-if="isWarningDisplayed" type="info">You have already received the Indigenous Programming Allowance for the current term.</AppAlertBanner>
+  <AppAlertBanner v-if="isWarningDisplayed" type="info">You have already received the Indigenous Programming Allowance for the current year.</AppAlertBanner>
   <v-row no-gutters class="mr-2 my-4">
     <v-col cols="12">
       <AppLabel>Purpose of the fund:</AppLabel>
@@ -11,7 +11,7 @@
   <v-row no-gutters class="mr-2 my-2">
     <v-col cols="12">
       <AppLabel>Eligible expenses:</AppLabel>
-      To reduce barriers to accessing these funds, all expenses are eligible except for staffing enhancements for the purpose of reducing ratio.
+      Eligible expenses: Expenses to enhance the participant's delivery of Indigenous curriculum in collaboration with Indigenous Peoples in their communities.
     </v-col>
   </v-row>
   <br />

--- a/frontend/src/components/supp-allowances/SupportNeedsProgrammingAllowance.vue
+++ b/frontend/src/components/supp-allowances/SupportNeedsProgrammingAllowance.vue
@@ -31,7 +31,7 @@
     <v-col cols="12">
       <strong>An Inclusion Policy is a requirement to apply for Support Needs Allowance.</strong>
       You can upload your policy in
-      <router-link to="/account-mgmt/manage-organization">Account Management.</router-link>
+      <router-link :to="{ name: 'manage-organization' }">Account Management.</router-link>
     </v-col>
   </v-row>
   <br />

--- a/frontend/src/components/supp-allowances/SupportNeedsProgrammingAllowance.vue
+++ b/frontend/src/components/supp-allowances/SupportNeedsProgrammingAllowance.vue
@@ -1,6 +1,5 @@
 <template>
   <AppAlertBanner v-if="isWarningDisplayed && hasInclusionPolicy" type="info">You have already received the Support Needs Allowance for the current year.</AppAlertBanner>
-
   <v-row no-gutters class="mr-2 my-2">
     <v-col cols="12">
       <AppAlertBanner v-if="!hasInclusionPolicy" type="info">
@@ -16,12 +15,10 @@
       Equipment, program resources, or minor Facility modifications to enhance inclusion for all children in the participant's programming.
       <br />
       <br />
-
       <AppLabel>Ineligible expenses include:</AppLabel>
       Staffing enhancements including support workers; individualized, therapeutic, or medical equipment.
       <br />
       <br />
-
       Providers can contact their local
       <a href="https://www2.gov.bc.ca/gov/content/health/managing-your-health/child-behaviour-development/early-childhood-intervention" target="_blank">
         Supported Child Development or Aboriginal Supported Child Development

--- a/frontend/src/components/supp-allowances/SupportNeedsProgrammingAllowance.vue
+++ b/frontend/src/components/supp-allowances/SupportNeedsProgrammingAllowance.vue
@@ -1,5 +1,5 @@
 <template>
-  <AppAlertBanner v-if="isWarningDisplayed && hasInclusionPolicy" type="info">You have already received the Support Needs Allowance for the current term.</AppAlertBanner>
+  <AppAlertBanner v-if="isWarningDisplayed && hasInclusionPolicy" type="info">You have already received the Support Needs Allowance for the current year.</AppAlertBanner>
 
   <v-row no-gutters class="mr-2 my-2">
     <v-col cols="12">
@@ -12,18 +12,28 @@
       meaningfully alongside other children.
       <br />
       <br />
-      Providers are encouraged to use this funding with their local
+      <AppLabel>Eligible expenses:</AppLabel>
+      Equipment, program resources, or minor Facility modifications to enhance inclusion for all children in the participant's programming.
+      <br />
+      <br />
+
+      <AppLabel>Ineligible expenses include:</AppLabel>
+      Staffing enhancements including support workers; individualized, therapeutic, or medical equipment.
+      <br />
+      <br />
+
+      Providers can contact their local
       <a href="https://www2.gov.bc.ca/gov/content/health/managing-your-health/child-behaviour-development/early-childhood-intervention" target="_blank">
         Supported Child Development or Aboriginal Supported Child Development
       </a>
-      programs.
+      programs for suggestions on how to use this funding.
     </v-col>
   </v-row>
   <br />
   <v-row no-gutters class="mr-2 my-2">
     <v-col cols="12">
       <strong>An Inclusion Policy is a requirement to apply for Support Needs Allowance.</strong>
-      Providers participating in the OFM Test must have an Inclusion Policy to receive this funding. You can upload your policy in
+      You can upload your policy in
       <router-link to="/account-mgmt/manage-organization">Account Management.</router-link>
     </v-col>
   </v-row>

--- a/frontend/src/components/supp-allowances/TransportationAllowance.vue
+++ b/frontend/src/components/supp-allowances/TransportationAllowance.vue
@@ -3,7 +3,6 @@
     <v-col cols="12">
       <AppLabel>Purpose of the fund:</AppLabel>
       Participants are eligible if using a designated vehicle to safely transport children:
-
       <v-row no-gutters>
         <v-col cols="12" class="mr-2 my-2">
           Between school and their offsite child care location;

--- a/frontend/src/components/supp-allowances/TransportationAllowance.vue
+++ b/frontend/src/components/supp-allowances/TransportationAllowance.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row no-gutters class="mr-2 my-2">
     <v-col cols="12">
-      <AppLabel>Eligibility:</AppLabel>
+      <AppLabel>Purpose of the fund:</AppLabel>
       Participants are eligible if using a designated vehicle to safely transport children:
 
       <v-row no-gutters>
@@ -33,7 +33,7 @@
     </v-col>
   </v-row>
 
-  <AppAlertBanner v-if="isWarningDisplayed" type="info">You have already received the Transportation Allowance for the current term. You may add another vehicle(s).</AppAlertBanner>
+  <AppAlertBanner v-if="isWarningDisplayed" type="info">You have already received the Transportation Allowance for the current year. You may add another vehicle(s).</AppAlertBanner>
 
   <v-divider class="my-5"></v-divider>
 

--- a/frontend/src/services/applicationService.js
+++ b/frontend/src/services/applicationService.js
@@ -29,11 +29,10 @@ export default {
       let applications = []
       await Promise.all(
         facilities?.map(async (facility) => {
-          let response = await ApiService.apiAxios.get(
+          const response = await ApiService.apiAxios.get(
             `${ApiRoutes.APPLICATIONS}?facilityId=${facility?.facilityId}&stateCode=${CRM_STATE_CODES.INACTIVE}&statusCode=${APPLICATION_STATUS_CODES.REDIRECTED}`,
           )
-          response = response.data
-          applications = applications?.concat(response)
+          applications = applications?.concat(response.data)
         }),
       )
       return applications

--- a/frontend/src/services/applicationService.js
+++ b/frontend/src/services/applicationService.js
@@ -32,7 +32,7 @@ export default {
           const response = await ApiService.apiAxios.get(
             `${ApiRoutes.APPLICATIONS}?facilityId=${facility?.facilityId}&stateCode=${CRM_STATE_CODES.INACTIVE}&statusCode=${APPLICATION_STATUS_CODES.REDIRECTED}`,
           )
-          applications = applications?.concat(response.data)
+          applications = applications?.concat(response?.data)
         }),
       )
       return applications

--- a/frontend/src/services/applicationService.js
+++ b/frontend/src/services/applicationService.js
@@ -24,11 +24,19 @@ export default {
     }
   },
 
-  async getRedirectedApplicationByFacilityId(facilityId) {
+  async getRedirectedApplications(facilities) {
     try {
-      if (!facilityId) return
-      const response = await ApiService.apiAxios.get(`${ApiRoutes.APPLICATIONS}?facilityId=${facilityId}&stateCode=${CRM_STATE_CODES.INACTIVE}&statusCode=${APPLICATION_STATUS_CODES.REDIRECTED}`)
-      return response?.data
+      let applications = []
+      await Promise.all(
+        facilities?.map(async (facility) => {
+          let response = await ApiService.apiAxios.get(
+            `${ApiRoutes.APPLICATIONS}?facilityId=${facility?.facilityId}&stateCode=${CRM_STATE_CODES.INACTIVE}&statusCode=${APPLICATION_STATUS_CODES.REDIRECTED}`,
+          )
+          response = response.data
+          applications = applications?.concat(response)
+        }),
+      )
+      return applications
     } catch (error) {
       console.log(`Failed to get the list of applications by facility id - ${error}`)
       throw error

--- a/frontend/src/services/applicationService.js
+++ b/frontend/src/services/applicationService.js
@@ -24,6 +24,17 @@ export default {
     }
   },
 
+  async getRedirectedApplicationByFacilityId(facilityId) {
+    try {
+      if (!facilityId) return
+      const response = await ApiService.apiAxios.get(`${ApiRoutes.APPLICATIONS}?facilityId=${facilityId}&stateCode=${CRM_STATE_CODES.INACTIVE}&statusCode=${APPLICATION_STATUS_CODES.REDIRECTED}`)
+      return response?.data
+    } catch (error) {
+      console.log(`Failed to get the list of applications by facility id - ${error}`)
+      throw error
+    }
+  },
+
   async getActiveApplications() {
     try {
       const authStore = useAuthStore()

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -72,6 +72,7 @@ export const APPLICATION_STATUS_CODES = Object.freeze({
   CANCELLED_BY_SP: 8, // INACTIVE state
   EXPIRED: 9, // INACTIVE state
   VERIFIED: 10,
+  REDIRECTED: 11, // INACTIVE state
 })
 
 export const FUNDING_AGREEMENT_STATUS_CODES = Object.freeze({
@@ -318,4 +319,14 @@ export const BUSINESS_TYPE_CODES = Object.freeze({
   PUBLIC_INSTITUTION: 3,
   LOCAL_GOVERNMENT: 4,
   SOLE_PROPRIETOR: 5,
+})
+
+export const PROVIDER_TYPE_CODES = Object.freeze({
+  GROUP: 1,
+  FAMILY: 2,
+})
+
+export const UNION_TYPE_CODES = Object.freeze({
+  NO: 0,
+  YES: 1,
 })

--- a/frontend/src/utils/constants/suppConstants.js
+++ b/frontend/src/utils/constants/suppConstants.js
@@ -6,7 +6,7 @@ export const INDIG_CHECKBOX_LABELS = Object.freeze([
   { label: 'Materials for a cultural program (beads, wood, food, etc.)', value: '3' },
   { label: 'Books, music, videos, and arts and crafts materials', value: '4' },
   { label: 'Culturally relevant toys and games', value: '5' },
-  { label: 'Facility décor enhancement-pictures, including artwork, outdoor play, and natural materials', value: '6' },
+  { label: 'Facility decor enhancement (pictures, including artwork, photos, outdoor structures, and natural materials)', value: '6' },
   { label: 'Field trips and outings', value: '7' },
   { label: 'Land-based play support', value: '8' },
   { label: 'Other', value: '9' },

--- a/frontend/src/views/applications/ApplicationConfirmationView.vue
+++ b/frontend/src/views/applications/ApplicationConfirmationView.vue
@@ -11,7 +11,7 @@
         </v-col>
       </v-row>
 
-      <v-card elevation="2" class="supp-applications-card">
+      <v-card v-if="hasNonUnionFacilityGroupOrg" elevation="2" class="supp-applications-card">
         <v-card-text class="px-8" py-6>
           <v-row no-gutters class="align-center">
             <v-col cols="12" md="8">
@@ -55,7 +55,7 @@ import AppButton from '@/components/ui/AppButton.vue'
 import AppBackButton from '@/components/ui/AppBackButton.vue'
 import AppAlertBanner from '../../components/ui/AppAlertBanner.vue'
 import alertMixin from '@/mixins/alertMixin'
-import { APPLICATION_STATUS_CODES, GOOD_STANDING_STATUS_CODES, NOT_IN_GOOD_STANDING_WARNING_MESSAGE } from '@/utils/constants'
+import { APPLICATION_STATUS_CODES, GOOD_STANDING_STATUS_CODES, NOT_IN_GOOD_STANDING_WARNING_MESSAGE, PROVIDER_TYPE_CODES, UNION_TYPE_CODES } from '@/utils/constants'
 import { useOrgStore } from '@/stores/org'
 import { useAuthStore } from '@/stores/auth'
 import { useApplicationsStore } from '@/stores/applications'
@@ -68,6 +68,7 @@ export default {
   data() {
     return {
       loading: false,
+      facility: undefined,
     }
   },
   computed: {
@@ -76,6 +77,12 @@ export default {
     ...mapState(useApplicationsStore, ['currentApplication']),
     hasGoodStanding() {
       return this.currentOrg?.goodStandingStatusCode === this.GOOD_STANDING_STATUS_CODES.GOOD
+    },
+    hasNonUnionFacilityGroupOrg() {
+      if (this.currentOrg?.providerType === PROVIDER_TYPE_CODES.FAMILY) {
+        return false
+      }
+      return this.currentApplication?.isUnionized === UNION_TYPE_CODES.NO
     },
   },
   async created() {

--- a/frontend/src/views/applications/ApplicationsHistoryView.vue
+++ b/frontend/src/views/applications/ApplicationsHistoryView.vue
@@ -339,17 +339,8 @@ export default {
     },
 
     async getRedirectedApplications() {
-      //if an application is redirected - it will not show up in the first call to getActiveApplications() and we will have a mismatch in application length
-      if (this.userInfo?.facilities.length === this.applications.length) return
-
-      this.userInfo?.facilities
-        .filter((fac) => !this.applications.some((el) => el.facilityId === fac.facilityId))
-        .forEach(async (fac) => {
-          const redirectedApp = await ApplicationService.getRedirectedApplicationByFacilityId(fac.facilityId)
-          if (redirectedApp.length) {
-            this.applications.push(redirectedApp[0]) //there will only ever be 1 redirected app - if redirected, they are essentially kicked out of OFM
-          }
-        })
+      const redirectedApplications = await ApplicationService.getRedirectedApplications(this.userInfo?.facilities.filter((fac) => !this.applications.some((el) => el.facilityId === fac.facilityId)))
+      this.applications = [...this.applications, ...redirectedApplications]
     },
 
     /**

--- a/frontend/src/views/applications/ApplicationsHistoryView.vue
+++ b/frontend/src/views/applications/ApplicationsHistoryView.vue
@@ -22,7 +22,7 @@
           </v-card>
         </v-col>
 
-        <v-col cols="12" md="6">
+        <v-col v-if="hasNonUnionFacilityGroupOrg" cols="12" md="6">
           <div v-if="!hasAValidApplicationAndGoodStanding && !loading">
             <AppAlertBanner v-if="!hasGoodStanding" type="warning">
               {{ NOT_IN_GOOD_STANDING_WARNING_MESSAGE }}
@@ -43,7 +43,7 @@
           </v-card>
         </v-col>
 
-        <v-col cols="12" md="6">
+        <v-col v-if="showIrregularExpenseCard" cols="12" md="6">
           <v-card class="basic-card justify-center">
             <v-card-title class="text-center text-wrap">
               <v-icon class="mr-2">mdi-file-document-edit-outline</v-icon>
@@ -55,9 +55,7 @@
               Funding requires approval before your facility incurs expenses, and you must demonstrate need for the funding.
             </v-card-text>
             <v-card-actions class="d-flex flex-column align-center">
-              <AppButton id="irregular-expense-button" :loading="loading" :disabled="!hasAValidFundingAgreement" class="ma-2 mt-8 text-wrap" @click="toggleChangeRequestDialog">
-                Add Irregular Expenses Funding Application
-              </AppButton>
+              <AppButton id="irregular-expense-button" :loading="loading" class="ma-2 mt-8 text-wrap" @click="toggleChangeRequestDialog">Add Irregular Expenses Funding Application</AppButton>
             </v-card-actions>
           </v-card>
         </v-col>
@@ -92,6 +90,16 @@
             {{ getApplicationAction(item) }}
           </router-link>
           <a v-else href="#table" @click="getPDF(item)">View Application</a>
+          <v-tooltip
+            v-if="item.statusCode === APPLICATION_STATUS_CODES.REDIRECTED"
+            content-class="tooltip"
+            text="Redirected applications are with the $10 a Day team for review. For next steps, please check your email.">
+            <template #activator="{ props }">
+              <v-btn v-bind="props" variant="text">
+                <v-icon size="large" v-bind="props">mdi-information-slab-circle-outline</v-icon>
+              </v-btn>
+            </template>
+          </v-tooltip>
         </template>
 
         <template #item.submittedDate="{ item }">
@@ -154,6 +162,8 @@ import {
   APPLICATION_TYPES,
   REQUEST_CATEGORY_NAMES,
   FUNDING_AGREEMENT_STATUS_CODES,
+  PROVIDER_TYPE_CODES,
+  UNION_TYPE_CODES,
 } from '@/utils/constants'
 import { mapState, mapActions } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
@@ -171,6 +181,7 @@ export default {
       supplementaryApplications: [],
       applicationItems: [],
       irregularExpenses: [],
+      redirectedApplications: [],
       headers: [
         { title: 'Application ID', key: 'referenceNumber', width: '6%' },
         { title: 'Application Type', key: 'applicationType', width: '12%' },
@@ -187,7 +198,6 @@ export default {
       cancelledApplicationId: undefined,
       facilityNameFilter: undefined,
       applicationTypeToCancel: undefined,
-      orgInfo: undefined,
       showChangeRequestDialog: false,
     }
   },
@@ -197,8 +207,8 @@ export default {
     ...mapState(useOrgStore, ['currentOrg']),
     ...mapState(useAppStore, ['getRequestCategoryIdByName']),
 
-    hasAValidFundingAgreement() {
-      return this.applications?.some((application) => application.fundingAgreement?.statusCode === FUNDING_AGREEMENT_STATUS_CODES.ACTIVE)
+    showIrregularExpenseCard() {
+      return this.applications?.some((application) => application.fundingAgreement?.statusCode === FUNDING_AGREEMENT_STATUS_CODES.ACTIVE && application?.isUnionized === UNION_TYPE_CODES.NO)
     },
 
     hasGoodStanding() {
@@ -227,6 +237,12 @@ export default {
     isCCOFEnrolmentCheckSatisfied() {
       return this.userInfo?.facilities?.some((facility) => facility.ccofEnrolmentCheckForAddApplication)
     },
+    hasNonUnionFacilityGroupOrg() {
+      if (this.currentOrg?.providerType === PROVIDER_TYPE_CODES.FAMILY) {
+        return false
+      }
+      return this.applications?.some((application) => application?.isUnionized === UNION_TYPE_CODES.NO)
+    },
   },
 
   async created() {
@@ -240,6 +256,7 @@ export default {
       this.DRAFT_STATUS_CODES = [APPLICATION_STATUS_CODES.DRAFT, SUPPLEMENTARY_APPLICATION_STATUS_CODES.DRAFT]
       this.NOT_IN_GOOD_STANDING_WARNING_MESSAGE = NOT_IN_GOOD_STANDING_WARNING_MESSAGE
       await this.getApplicationsAndFundingAgreement()
+      await this.getRedirectedApplications()
       await this.getSupplementaryApplications()
       await this.getIrregularExpenseApplications()
       this.mergeRegularAndSupplementaryApplications()
@@ -258,7 +275,9 @@ export default {
     ...mapActions(useOrgStore, ['getOrganizationInfo']),
     isEmpty,
     getApplicationAction(application) {
-      if (this.DRAFT_STATUS_CODES.includes(application?.statusCode)) {
+      if (application.statusCode === APPLICATION_STATUS_CODES.REDIRECTED) {
+        return ''
+      } else if (this.DRAFT_STATUS_CODES.includes(application?.statusCode)) {
         return this.hasPermission(this.PERMISSIONS.APPLY_FOR_FUNDING) ? 'Continue Application' : 'View Application'
       }
       return 'View Application'
@@ -268,11 +287,11 @@ export default {
     },
 
     showPDFDownloadButton(application) {
-      //OFM core generates PDF upon submit - Supp App generates PDF only once approved
-      if (application.applicationType === APPLICATION_TYPES.OFM) {
-        return !this.DRAFT_STATUS_CODES.includes(application?.statusCode)
-      } else if (application.applicationType === APPLICATION_TYPES.IRREGULAR_EXPENSE) {
+      if (application.applicationType === APPLICATION_TYPES.IRREGULAR_EXPENSE || application.statusCode === APPLICATION_STATUS_CODES.REDIRECTED) {
         return false
+        //OFM core generates PDF upon submit - Supp App generates PDF only once approved
+      } else if (application.applicationType === APPLICATION_TYPES.OFM) {
+        return !this.DRAFT_STATUS_CODES.includes(application?.statusCode)
       }
       return application.statusCode === SUPPLEMENTARY_APPLICATION_STATUS_CODES.APPROVED || application.statusCode === SUPPLEMENTARY_APPLICATION_STATUS_CODES.SUBMITTED
     },
@@ -315,9 +334,25 @@ export default {
     },
 
     async getSupplementaryApplications() {
-      this.supplementaryApplications = (await Promise.all(this.applications.map((application) => ApplicationService.getSupplementaryApplications(application.applicationId))))
-        .filter((application) => application.length > 0)
+      this.supplementaryApplications = (await Promise.all(this.applications.map((application) => ApplicationService.getSupplementaryApplications(application?.applicationId))))
+        .filter((application) => application?.length > 0)
         .flat()
+    },
+
+    async getRedirectedApplications() {
+      //if an application is redirected - it will not show up in the first call to getActiveApplications() and
+      if (this.userInfo?.facilities.length === this.applications.length) return
+
+      const redirectedApplications = await Promise.all(
+        this.userInfo?.facilities
+          .filter((fac) => !this.applications.some((el) => el.facilityId === fac.facilityId))
+          .map(async (fac) => {
+            const redirectedApp = await ApplicationService.getRedirectedApplicationByFacilityId(fac.facilityId)
+            if (redirectedApp) return redirectedApp[0] //there will only ever be 1 redirected app - if redirected, they are essentially kicked out of OFM
+          }),
+      )
+
+      this.applications.push(...redirectedApplications)
     },
 
     /**
@@ -386,7 +421,7 @@ export default {
     },
 
     getStatusClass(statusCode) {
-      if (this.DRAFT_STATUS_CODES.includes(statusCode)) {
+      if (this.DRAFT_STATUS_CODES.includes(statusCode) || statusCode === APPLICATION_STATUS_CODES.REDIRECTED) {
         return 'status-gray'
       } else if (
         [

--- a/frontend/src/views/applications/ApplicationsHistoryView.vue
+++ b/frontend/src/views/applications/ApplicationsHistoryView.vue
@@ -258,7 +258,6 @@ export default {
       await this.getRedirectedApplications()
       await this.getSupplementaryApplications()
       await this.getIrregularExpenseApplications()
-
       this.mergeRegularAndSupplementaryApplications()
 
       if (!this.currentOrg) {

--- a/frontend/src/views/applications/SelectFacilityView.vue
+++ b/frontend/src/views/applications/SelectFacilityView.vue
@@ -108,7 +108,12 @@ export default {
     ...mapWritableState(useApplicationsStore, ['isSelectFacilityComplete']),
 
     filteredFacilities() {
-      return this.userInfo?.facilities?.filter((facility) => facility.intakeWindowCheckForAddApplication && facility.ccofEnrolmentCheckForAddApplication)
+      return this.userInfo?.facilities?.filter(
+        (facility) =>
+          facility.intakeWindowCheckForAddApplication &&
+          facility.ccofEnrolmentCheckForAddApplication &&
+          this.loadedApplications?.find((el) => el.facilityId === facility.facilityId && el.statusCode !== APPLICATION_STATUS_CODES.REDIRECTED),
+      )
     },
   },
 
@@ -160,6 +165,16 @@ export default {
     }
     await this.getOrganization()
     this.loadedApplications = await ApplicationService.getActiveApplications()
+
+    //get the redirected applications so we can prevent those facilities from starting another OFM app
+    this.userInfo?.facilities
+      .filter((fac) => !this.loadedApplications.some((el) => el.facilityId === fac.facilityId))
+      .forEach(async (fac) => {
+        const redirectedApp = await ApplicationService.getRedirectedApplicationByFacilityId(fac.facilityId)
+        if (redirectedApp.length) {
+          this.loadedApplications.push(redirectedApp[0])
+        }
+      })
   },
 
   methods: {

--- a/frontend/src/views/applications/SelectFacilityView.vue
+++ b/frontend/src/views/applications/SelectFacilityView.vue
@@ -112,7 +112,7 @@ export default {
         (facility) =>
           facility.intakeWindowCheckForAddApplication &&
           facility.ccofEnrolmentCheckForAddApplication &&
-          this.loadedApplications?.find((el) => el.facilityId === facility.facilityId && el.statusCode !== APPLICATION_STATUS_CODES.REDIRECTED),
+          this.loadedApplications?.some((el) => el.facilityId === facility.facilityId && el.statusCode !== APPLICATION_STATUS_CODES.REDIRECTED),
       )
     },
   },
@@ -167,14 +167,10 @@ export default {
     this.loadedApplications = await ApplicationService.getActiveApplications()
 
     //get the redirected applications so we can prevent those facilities from starting another OFM app
-    this.userInfo?.facilities
-      .filter((fac) => !this.loadedApplications.some((el) => el.facilityId === fac.facilityId))
-      .forEach(async (fac) => {
-        const redirectedApp = await ApplicationService.getRedirectedApplicationByFacilityId(fac.facilityId)
-        if (redirectedApp.length) {
-          this.loadedApplications.push(redirectedApp[0])
-        }
-      })
+    const redirectedApplications = await ApplicationService.getRedirectedApplications(
+      this.userInfo?.facilities.filter((fac) => !this.loadedApplications.some((el) => el.facilityId === fac.facilityId)),
+    )
+    this.loadedApplications = [...this.loadedApplications, ...redirectedApplications]
   },
 
   methods: {

--- a/frontend/src/views/applications/SelectFacilityView.vue
+++ b/frontend/src/views/applications/SelectFacilityView.vue
@@ -100,6 +100,7 @@ export default {
       loadedApplications: undefined,
       documentsToDelete: [],
       documentsComplete: true,
+      redirectedApplications: undefined,
     }
   },
 
@@ -109,10 +110,7 @@ export default {
 
     filteredFacilities() {
       return this.userInfo?.facilities?.filter(
-        (facility) =>
-          facility.intakeWindowCheckForAddApplication &&
-          facility.ccofEnrolmentCheckForAddApplication &&
-          this.loadedApplications?.some((el) => el.facilityId === facility.facilityId && el.statusCode !== APPLICATION_STATUS_CODES.REDIRECTED),
+        (facility) => facility.intakeWindowCheckForAddApplication && facility.ccofEnrolmentCheckForAddApplication && !this.redirectedApplications?.some((el) => el.facilityId === facility.facilityId),
       )
     },
   },
@@ -167,10 +165,7 @@ export default {
     this.loadedApplications = await ApplicationService.getActiveApplications()
 
     //get the redirected applications so we can prevent those facilities from starting another OFM app
-    const redirectedApplications = await ApplicationService.getRedirectedApplications(
-      this.userInfo?.facilities.filter((fac) => !this.loadedApplications.some((el) => el.facilityId === fac.facilityId)),
-    )
-    this.loadedApplications = [...this.loadedApplications, ...redirectedApplications]
+    this.redirectedApplications = await ApplicationService.getRedirectedApplications(this.userInfo?.facilities.filter((fac) => !this.loadedApplications.some((el) => el.facilityId === fac.facilityId)))
   },
 
   methods: {

--- a/frontend/src/views/supp-allowances/SupplementaryAllowanceView.vue
+++ b/frontend/src/views/supp-allowances/SupplementaryAllowanceView.vue
@@ -74,6 +74,7 @@ import permissionsMixin from '@/mixins/permissionsMixin'
 import { isEmpty } from 'lodash'
 import rules from '@/utils/rules'
 import { useOrgStore } from '@/stores/org'
+import { UNION_TYPE_CODES } from '@/utils/constants'
 
 export default {
   name: 'SupplementaryAllowanceView',
@@ -166,7 +167,7 @@ export default {
     },
 
     getValidApplication(facilityId) {
-      return this.applications?.find((application) => application.facilityId === facilityId && ApplicationService.isValidApplication(application))
+      return this.applications?.find((application) => application.facilityId === facilityId && ApplicationService.isValidApplication(application) && application?.isUnionized === UNION_TYPE_CODES.NO)
     },
 
     process(value) {

--- a/frontend/src/views/supp-allowances/SupplementaryAllowanceView.vue
+++ b/frontend/src/views/supp-allowances/SupplementaryAllowanceView.vue
@@ -28,7 +28,7 @@
           </v-col>
         </v-row>
         <div v-if="application">
-          <span>You are applying this program for the Application&ensp;</span>
+          <span>You are applying for this allowance linked to your base funding &ensp;</span>
           <span class="application-number">{{ application?.referenceNumber }}</span>
           <router-view
             :key="application?.applicationId"

--- a/frontend/src/views/supp-allowances/SupplementaryConfirmation.vue
+++ b/frontend/src/views/supp-allowances/SupplementaryConfirmation.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="mt-16">
     <div class="mt-16">
-      <h2 class="mb-8 text-center">Allowances Application Submitted</h2>
+      <h2 class="mb-8 text-center">Allowances (Core and Discretionary Services) Application Submitted</h2>
       <h4 class="mb-8 text-center">Check your dashboard for updates on the progress of your application. We may reach out if we need more information</h4>
 
       <v-row justify="space-around" no-gutters class="mt-10">

--- a/frontend/src/views/supp-allowances/SupplementaryFormView.vue
+++ b/frontend/src/views/supp-allowances/SupplementaryFormView.vue
@@ -1,16 +1,21 @@
-<!-- eslint-disable vue/attribute-hyphenation -->
 <template>
   <p class="my-11">
-    Currently, there are three Operating Funding Model Allowances available. Please check them and apply for
-    <strong class="text-decoration-underline">one or all</strong>
-    that applies to your organization.
+    Allowances (Core and Discretionary) have a one-year term. You must re-apply annually to continue receiving funding.
+    <br />
+    The renewal date will be the anniversary of your OFM base funding agreement
+  </p>
+
+  <p class="my-11">
+    You may apply for one or more allowances. You may also apply through
+    <router-link :to="{ name: 'applications-history' }">Applications</router-link>
+    at any time.
   </p>
 
   <AppAlertBanner v-if="currentTermDisabled" type="warning">Your current year funding is ending and you are no longer able to make changes. Please apply for Next Year</AppAlertBanner>
 
   <v-form ref="form">
     <v-row no-gutters class="mb-2">
-      <v-col cols="12" lg="1">
+      <v-col cols="12" lg="2">
         <AppLabel>Application Year:</AppLabel>
       </v-col>
 

--- a/frontend/src/views/supp-allowances/SupplementarySubmitView.vue
+++ b/frontend/src/views/supp-allowances/SupplementarySubmitView.vue
@@ -1,4 +1,9 @@
 <template>
+  <p class="my-11">
+    Your application is almost ready to submit. Please check and review all your inputs.
+    <br />
+    You will not be able to change these details after submission
+  </p>
   <v-form ref="form" class="mt-10">
     <v-row v-if="!loading" no-gutters class="mb-2">
       <v-col cols="12" align="right">

--- a/frontend/src/views/supp-allowances/SupplementarySubmitView.vue
+++ b/frontend/src/views/supp-allowances/SupplementarySubmitView.vue
@@ -1,6 +1,5 @@
 <template>
   <v-form ref="form" class="mt-10">
-    <h2>Allowances (Core and Discretionary Services)</h2>
     <v-row v-if="!loading" no-gutters class="mb-2">
       <v-col cols="12" align="right">
         <AppButton v-if="isEmpty(panel)" id="expand-button" :primary="false" size="large" width="200px" @click="togglePanel">


### PR DESCRIPTION
- Add Redirected Applications to App History Table 
- Show / Hide Supp apps/ Irregular expenses based on union/ family flags 
- Wording updates that I missed on the Supp Apps page
- Filter Supp Apps / Irreg Expense dropdowns to only include eligible facilities -

** note- in some places I call getFacility, in others I look at the answer on the applications to check for the isUnionized flag. I am not a huge fan of the inconsistency - so let me know if you think I should change this. I did it this way to reduce API calls on applicationHistory page. 

 