### PR TITLE
fix: remove branch from matchlabels

### DIFF
--- a/tools/openshift/backend.deployment.yaml
+++ b/tools/openshift/backend.deployment.yaml
@@ -12,14 +12,14 @@ objects:
       annotations:
         openshift.io/generated-by: OpenShiftNewApp
       labels:
-        app: '${APP_NAME}-backend-${ENVIRONMENT}-${BRANCH}'
+        app: '${APP_NAME}-backend-${ENVIRONMENT}'
         branch: '${BRANCH}'
       name: '${APP_NAME}-backend-${ENVIRONMENT}'
     spec:
       replicas: ${{MIN_REPLICAS}}
       selector:
         matchLabels:
-          app: '${APP_NAME}-backend-${ENVIRONMENT}-${BRANCH}'
+          app: '${APP_NAME}-backend-${ENVIRONMENT}'
       strategy:
         type: RollingUpdate
         rollingUpdate:
@@ -30,7 +30,7 @@ objects:
           annotations:
             openshift.io/generated-by: OpenShiftNewApp
           labels:
-            app: '${APP_NAME}-backend-${ENVIRONMENT}-${BRANCH}'
+            app: '${APP_NAME}-backend-${ENVIRONMENT}'
         spec:
           containers:
             - image: image-registry.openshift-image-registry.svc:5000/${NAMESPACE}/${REPO_NAME}-backend:${TAG}
@@ -126,7 +126,7 @@ objects:
         service.alpha.openshift.io/serving-cert-secret-name: 'ofm-backend-cert'
         openshift.io/generated-by: OpenShiftNewApp
       labels:
-        app: '${APP_NAME}-backend-${ENVIRONMENT}-${BRANCH}'
+        app: '${APP_NAME}-backend-${ENVIRONMENT}'
       name: '${APP_NAME}-backend-${ENVIRONMENT}'
     spec:
       ports:
@@ -139,13 +139,13 @@ objects:
           protocol: TCP
           targetPort: 443
       selector:
-        app: '${APP_NAME}-backend-${ENVIRONMENT}-${BRANCH}'
+        app: '${APP_NAME}-backend-${ENVIRONMENT}'
   - apiVersion: v1
     kind: Route
     metadata:
       name: '${APP_NAME}-backend-${ENVIRONMENT}'
       labels:
-        app: '${APP_NAME}-backend-${ENVIRONMENT}-${BRANCH}'
+        app: '${APP_NAME}-backend-${ENVIRONMENT}'
       annotations:
         openshift.io/host.generated: 'true'
         router.openshift.io/cookie-same-site: 'Strict'

--- a/tools/openshift/frontend-tls.deployment.yaml
+++ b/tools/openshift/frontend-tls.deployment.yaml
@@ -13,14 +13,14 @@ objects:
         openshift.io/generated-by: OpenShiftNewApp
       creationTimestamp:
       labels:
-        app: '${APP_NAME}-frontend-${ENVIRONMENT}-${BRANCH}'
+        app: '${APP_NAME}-frontend-${ENVIRONMENT}'
         branch: '${BRANCH}'
       name: '${APP_NAME}-frontend-${ENVIRONMENT}'
     spec:
       replicas: ${{MIN_REPLICAS}}
       selector:
         matchLabels:
-          app: '${APP_NAME}-frontend-${ENVIRONMENT}-${BRANCH}'
+          app: '${APP_NAME}-frontend-${ENVIRONMENT}'
       strategy:
         type: RollingUpdate
         rollingUpdate:
@@ -32,7 +32,7 @@ objects:
             openshift.io/generated-by: OpenShiftNewApp
           creationTimestamp:
           labels:
-            app: '${APP_NAME}-frontend-${ENVIRONMENT}-${BRANCH}'
+            app: '${APP_NAME}-frontend-${ENVIRONMENT}'
             deploymentconfig: '${APP_NAME}-frontend-${ENVIRONMENT}'
         spec:
           containers:
@@ -89,7 +89,7 @@ objects:
         openshift.io/generated-by: OpenShiftNewApp
       creationTimestamp:
       labels:
-        app: '${APP_NAME}-frontend-${ENVIRONMENT}-${BRANCH}'
+        app: '${APP_NAME}-frontend-${ENVIRONMENT}'
       name: '${APP_NAME}-frontend-${ENVIRONMENT}'
     spec:
       ports:
@@ -98,14 +98,14 @@ objects:
           protocol: TCP
           targetPort: 2015
       selector:
-        app: '${APP_NAME}-frontend-${ENVIRONMENT}-${BRANCH}'
+        app: '${APP_NAME}-frontend-${ENVIRONMENT}'
         deploymentconfig: '${APP_NAME}-frontend-${ENVIRONMENT}'
   - apiVersion: v1
     kind: Route
     metadata:
       name: '${APP_NAME}-frontend-${ENVIRONMENT}'
       labels:
-        app: '${APP_NAME}-frontend-${ENVIRONMENT}-${BRANCH}'
+        app: '${APP_NAME}-frontend-${ENVIRONMENT}'
       annotations:
         openshift.io/host.generated: 'true'
         router.openshift.io/cookie-same-site: 'Strict'

--- a/tools/openshift/frontend.deployment.yaml
+++ b/tools/openshift/frontend.deployment.yaml
@@ -12,14 +12,14 @@ objects:
       annotations:
         openshift.io/generated-by: OpenShiftNewApp
       labels:
-        app: '${APP_NAME}-frontend-${ENVIRONMENT}-${BRANCH}'
+        app: '${APP_NAME}-frontend-${ENVIRONMENT}'
         branch: '${BRANCH}'
       name: '${APP_NAME}-frontend-${ENVIRONMENT}'
     spec:
       replicas: ${{MIN_REPLICAS}}
       selector:
         matchLabels:
-          app: '${APP_NAME}-frontend-${ENVIRONMENT}-${BRANCH}'
+          app: '${APP_NAME}-frontend-${ENVIRONMENT}'
       strategy:
         type: RollingUpdate
         rollingUpdate:
@@ -30,7 +30,7 @@ objects:
           annotations:
             openshift.io/generated-by: OpenShiftNewApp
           labels:
-            app: '${APP_NAME}-frontend-${ENVIRONMENT}-${BRANCH}'
+            app: '${APP_NAME}-frontend-${ENVIRONMENT}'
         spec:
           containers:
             - image: image-registry.openshift-image-registry.svc:5000/${NAMESPACE}/${REPO_NAME}-frontend:${TAG}
@@ -79,7 +79,7 @@ objects:
         service.alpha.openshift.io/serving-cert-secret-name: 'ofm-frontend-cert'
         openshift.io/generated-by: OpenShiftNewApp
       labels:
-        app: '${APP_NAME}-frontend-${ENVIRONMENT}-${BRANCH}'
+        app: '${APP_NAME}-frontend-${ENVIRONMENT}'
       name: '${APP_NAME}-frontend-${ENVIRONMENT}'
     spec:
       ports:
@@ -88,13 +88,13 @@ objects:
           protocol: TCP
           targetPort: 2015
       selector:
-        app: '${APP_NAME}-frontend-${ENVIRONMENT}-${BRANCH}'
+        app: '${APP_NAME}-frontend-${ENVIRONMENT}'
   - apiVersion: v1
     kind: Route
     metadata:
       name: '${APP_NAME}-frontend-${ENVIRONMENT}'
       labels:
-        app: '${APP_NAME}-frontend-${ENVIRONMENT}-${BRANCH}'
+        app: '${APP_NAME}-frontend-${ENVIRONMENT}'
       annotations:
         openshift.io/host.generated: 'true'
         router.openshift.io/cookie-same-site: 'Strict'


### PR DESCRIPTION
This should let us deploy from branches without running into the deployment matchlabel immutability error