### PR TITLE
removed banner for facility filter

### DIFF
--- a/frontend/src/components/funding/FundingAllocationTab.vue
+++ b/frontend/src/components/funding/FundingAllocationTab.vue
@@ -13,9 +13,6 @@
       No Active Funding Agreement Found: This organization currently does not have an active signed OFM funding agreement.
     </AppAlertBanner>
     <div v-else>
-      <AppAlertBanner type="info" class="ma-2 mb-4">
-        Note: If the facility you're looking for does not appear in the dropdown list, that facility may not have an active signed OFM funding agreement.
-      </AppAlertBanner>
       <FundingSearchCard :loading="loading" :select-single-facility="true" :show-date-filter="false" :show-reset-button="false" class="my-10" @search="loadFundingDetails" />
       <BaseFundingCard :loading="loading" :funding-details="fundingDetails" />
       <div v-if="showTopupCard">


### PR DESCRIPTION
https://eccbc.atlassian.net/browse/OFMCC-7286
After further discussion the following has been decided:

**Remove :** Banner under Search Facility title that says “Note: If the facility you're looking for does not appear in the dropdown list, that facility may not have an active signed OFM funding agreement.”

**Keep:**

- “Facility Search” title added above search facility drop down menu

- Conditional wording when the organization has no active signed funding agreement, everything below “Search Facility” will not be shown and there will be a banner that says “No Active Funding Agreement Found: This organization currently does not have an active signed OFM funding agreement.”